### PR TITLE
build: upstream source modifications

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceTableSchema.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceTableSchema.java
@@ -21,6 +21,7 @@ import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedT
 import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapper.MapperType;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.util.UUID;
@@ -59,6 +60,8 @@ public abstract class SourceTableSchema implements Serializable {
   // Mapped Avro Schema (to unified types) that each row will carry.
   public abstract Schema avroSchema();
 
+  public abstract ImmutableList<String> primaryKeyColumns();
+
   public Schema getAvroPayload() {
     return avroSchema().getField(PAYLOAD_FIELD_NAME).schema();
   }
@@ -90,6 +93,8 @@ public abstract class SourceTableSchema implements Serializable {
 
     abstract ImmutableMap.Builder<String, SourceColumnType>
         sourceColumnNameToSourceColumnTypeBuilder();
+
+    public abstract Builder setPrimaryKeyColumns(ImmutableList<String> value);
 
     private FieldAssembler<RecordDefault<Schema>> payloadFieldAssembler;
 
@@ -132,6 +137,7 @@ public abstract class SourceTableSchema implements Serializable {
 
     public Builder initialize(UnifiedTypeMapper.MapperType mapperType) {
       this.mapperType = mapperType;
+      this.setPrimaryKeyColumns(ImmutableList.of());
       return this;
     }
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/MigrateTableTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/MigrateTableTransform.java
@@ -183,15 +183,12 @@ public class MigrateTableTransform extends PTransform<PBegin, PCollection<Void>>
     return sourceRows.apply(
         "WriteAvroToGCS",
         FileIO.<AvroDestination, SourceRow>writeDynamic()
-            .by(
-                (record) ->
-                    AvroDestination.of(
-                        record.tableName(), record.getPayload().getSchema().toString()))
+            .by((record) -> AvroDestination.of(record.tableName(), record.gcsSchema().toString()))
             .via(
                 Contextful.fn(
                     record -> {
                       Metrics.counter(MigrateTableTransform.class, metricName).inc();
-                      return record.getPayload();
+                      return record.toGcsRecord();
                     }),
                 Contextful.fn(destination -> AvroIO.sink(destination.jsonSchema)))
             .withDestinationCoder(AvroCoder.of(AvroDestination.class))

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
@@ -125,6 +125,7 @@ public class JdbcIoWrapperTest {
     assertThat(tableSchema.tableName()).isEqualTo("testTable");
     assertThat(tableSchema.sourceColumnNameToSourceColumnType())
         .isEqualTo(ImmutableMap.of(testCol, testColType));
+    assertThat(tableSchema.primaryKeyColumns()).isEqualTo(ImmutableList.of(testCol));
     ImmutableMap<SourceTableReference, PTransform<PBegin, PCollection<SourceRow>>> tableReaders =
         jdbcIoWrapper.getTableReaders();
     assertThat(tableReaders.size()).isEqualTo(1);
@@ -177,6 +178,7 @@ public class JdbcIoWrapperTest {
     assertThat(tableSchema.tableName()).isEqualTo("testTable");
     assertThat(tableSchema.sourceColumnNameToSourceColumnType())
         .isEqualTo(ImmutableMap.of(testCol, testColType));
+    assertThat(tableSchema.primaryKeyColumns()).isEqualTo(ImmutableList.of(testCol));
     ImmutableMap<SourceTableReference, PTransform<PBegin, PCollection<SourceRow>>> tableReaders =
         jdbcIoWrapper.getTableReaders();
     assertThat(tableReaders.size()).isEqualTo(1);

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaTestUtils.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaTestUtils.java
@@ -22,21 +22,24 @@ import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 /** Test Utility class for Generating test schema. */
 public class SchemaTestUtils {
 
-  static final String TEST_FIELD_NAME_1 = "firstName";
-  static final String TEST_FIELD_NAME_2 = "lastName";
+  public static final String TEST_FIELD_NAME_1 = "firstName";
+  public static final String TEST_FIELD_NAME_2 = "lastName";
 
   public static SourceSchemaReference generateSchemaReference(String namespace, String dbName) {
     return SourceSchemaReference.ofJdbc(
         JdbcSchemaReference.builder().setNamespace(namespace).setDbName(dbName).build());
   }
 
-  public static SourceTableSchema generateTestTableSchema(String tableName) {
+  public static SourceTableSchema.Builder generateTestTableSchemaBuilder(String tableName) {
     return SourceTableSchema.builder(SQLDialect.MYSQL)
         .setTableName(tableName)
         .addSourceColumnNameToSourceColumnType(
             TEST_FIELD_NAME_1, new SourceColumnType("varchar", new Long[] {20L}, null))
         .addSourceColumnNameToSourceColumnType(
-            TEST_FIELD_NAME_2, new SourceColumnType("varchar", new Long[] {20L}, null))
-        .build();
+            TEST_FIELD_NAME_2, new SourceColumnType("varchar", new Long[] {20L}, null));
+  }
+
+  public static SourceTableSchema generateTestTableSchema(String tableName) {
+    return generateTestTableSchemaBuilder(tableName).build();
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceTableSchemaTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceTableSchemaTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
 import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapper.MapperType;
+import com.google.common.collect.ImmutableList;
 import junit.framework.TestCase;
 import org.apache.avro.SchemaBuilder;
 import org.junit.Assert;
@@ -48,6 +49,22 @@ public class SourceTableSchemaTest extends TestCase {
             sourceTableSchema.getAvroPayload().getField(SchemaTestUtils.TEST_FIELD_NAME_2).schema())
         .isEqualTo(SchemaBuilder.unionOf().nullType().and().stringType().endUnion());
     assertThat(sourceTableSchema.tableName()).isEqualTo(testTableName);
+    assertThat(sourceTableSchema.primaryKeyColumns()).isEmpty();
+  }
+
+  @Test
+  public void testTableSchemaWithPrimaryKey() {
+    final String testTableName = "testTableName";
+    var sourceTableSchema =
+        SchemaTestUtils.generateTestTableSchemaBuilder(testTableName)
+            .setPrimaryKeyColumns(
+                ImmutableList.of(
+                    SchemaTestUtils.TEST_FIELD_NAME_1, SchemaTestUtils.TEST_FIELD_NAME_2))
+            .build();
+    assertThat(sourceTableSchema.tableName()).isEqualTo(testTableName);
+    assertThat(sourceTableSchema.primaryKeyColumns())
+        .containsExactly(SchemaTestUtils.TEST_FIELD_NAME_1, SchemaTestUtils.TEST_FIELD_NAME_2)
+        .inOrder();
   }
 
   @Test


### PR DESCRIPTION
### TL;DR

Added primary key information to the source schema and enhanced GCS output format to include metadata.

### What changed?

- Enhanced `JdbcIoWrapper` to discover and include primary key information from source tables
- Added primary key columns to `SourceTableSchema` to track this information
- Extended `SourceRow` with new methods:
  - `gcsSchema()` to generate a schema that includes metadata fields
  - `toGcsRecord()` to convert a SourceRow into a GenericRecord with metadata
- Modified the GCS write process to use the enhanced schema format that includes table name, shard ID, primary keys, and payload

### How to test?

1. Run a migration job that reads from a source database and writes to GCS
2. Verify that the Avro files in GCS contain the expected metadata fields (tableName, shardId, primaryKeys)
3. Confirm that primary key information is correctly extracted from source tables
4. Check that the payload data remains intact and properly structured

### Why make this change?

This change enhances the data migration process by preserving primary key information from source tables, which is critical for maintaining data integrity and relationships. The enriched GCS output format with metadata makes downstream processing more efficient by including important structural information alongside the data payload, eliminating the need to rediscover this information later in the pipeline.