### PR TITLE
feat(dv): scaffold module, constants, and data transfer objects (DTOs)

### DIFF
--- a/v2/gcs-spanner-dv/pom.xml
+++ b/v2/gcs-spanner-dv/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (C) 2026 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.cloud.teleport.v2</groupId>
+    <artifactId>dynamic-templates</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>gcs-spanner-dv</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud.teleport.v2</groupId>
+      <artifactId>common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+    </dependency>
+
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>com.google.cloud.teleport</groupId>
+      <artifactId>it-google-cloud-platform</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-it-jdbc</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.teleport.v2</groupId>
+      <artifactId>spanner-common</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>LATEST</version> <!-- Use the latest version available -->
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/constants/GCSSpannerDVConstants.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/constants/GCSSpannerDVConstants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.constants;
+
+import com.google.cloud.teleport.v2.dto.ComparisonRecord;
+import org.apache.beam.sdk.values.TupleTag;
+
+public class GCSSpannerDVConstants {
+
+  public static final TupleTag<ComparisonRecord> SOURCE_TAG = new TupleTag<ComparisonRecord>() {};
+  public static final TupleTag<ComparisonRecord> SPANNER_TAG = new TupleTag<ComparisonRecord>() {};
+  public static final TupleTag<ComparisonRecord> MATCHED_TAG = new TupleTag<ComparisonRecord>() {};
+  public static final TupleTag<ComparisonRecord> MISSING_IN_SPANNER_TAG =
+      new TupleTag<ComparisonRecord>() {};
+  public static final TupleTag<ComparisonRecord> MISSING_IN_SOURCE_TAG =
+      new TupleTag<ComparisonRecord>() {};
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/constants/package-info.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/constants/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.constants;

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dofn/package-info.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dofn/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dofn;

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/BigQuerySchemas.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/BigQuerySchemas.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dto;
+
+import com.google.api.services.bigquery.model.TableFieldSchema;
+import com.google.api.services.bigquery.model.TableSchema;
+import com.google.common.collect.Lists;
+
+/** BigQuery schemas for the GCS to Spanner Data Validation pipeline. */
+public final class BigQuerySchemas {
+
+  private BigQuerySchemas() {}
+
+  public static final TableSchema MISMATCHED_RECORDS_SCHEMA =
+      new TableSchema()
+          .setFields(
+              Lists.newArrayList(
+                  new TableFieldSchema()
+                      .setName(MismatchedRecord.RUN_ID_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(MismatchedRecord.TABLE_NAME_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(MismatchedRecord.MISMATCH_TYPE_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(MismatchedRecord.RECORD_KEY_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(MismatchedRecord.SOURCE_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(MismatchedRecord.HASH_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("REQUIRED")));
+
+  public static final TableSchema TABLE_VALIDATION_STATS_SCHEMA =
+      new TableSchema()
+          .setFields(
+              Lists.newArrayList(
+                  new TableFieldSchema()
+                      .setName(TableValidationStats.RUN_ID_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(TableValidationStats.TABLE_NAME_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(TableValidationStats.STATUS_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(TableValidationStats.SOURCE_ROW_COUNT_COLUMN_NAME)
+                      .setType("INTEGER")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(TableValidationStats.DESTINATION_ROW_COUNT_COLUMN_NAME)
+                      .setType("INTEGER")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(TableValidationStats.MATCHED_ROW_COUNT_COLUMN_NAME)
+                      .setType("INTEGER")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(TableValidationStats.MISMATCH_ROW_COUNT_COLUMN_NAME)
+                      .setType("INTEGER")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(TableValidationStats.START_TIMESTAMP_COLUMN_NAME)
+                      .setType("TIMESTAMP")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(TableValidationStats.END_TIMESTAMP_COLUMN_NAME)
+                      .setType("TIMESTAMP")
+                      .setMode("REQUIRED")));
+
+  public static final TableSchema VALIDATION_SUMMARY_SCHEMA =
+      new TableSchema()
+          .setFields(
+              Lists.newArrayList(
+                  new TableFieldSchema()
+                      .setName(ValidationSummary.RUN_ID_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(ValidationSummary.SOURCE_DATABASE_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("NULLABLE"),
+                  new TableFieldSchema()
+                      .setName(ValidationSummary.DESTINATION_DATABASE_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("NULLABLE"),
+                  new TableFieldSchema()
+                      .setName(ValidationSummary.STATUS_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(ValidationSummary.TOTAL_TABLES_VALIDATED_COLUMN_NAME)
+                      .setType("INTEGER")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(ValidationSummary.TABLES_WITH_MISMATCHES_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("NULLABLE"),
+                  new TableFieldSchema()
+                      .setName(ValidationSummary.TOTAL_ROWS_MATCHED_COLUMN_NAME)
+                      .setType("INTEGER")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(ValidationSummary.TOTAL_ROWS_MISMATCHED_COLUMN_NAME)
+                      .setType("INTEGER")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(ValidationSummary.START_TIMESTAMP_COLUMN_NAME)
+                      .setType("TIMESTAMP")
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(ValidationSummary.END_TIMESTAMP_COLUMN_NAME)
+                      .setType("TIMESTAMP")
+                      .setMode("REQUIRED")));
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/Column.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/Column.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dto;
+
+import com.google.auto.value.AutoValue;
+import org.apache.beam.sdk.schemas.AutoValueSchema;
+import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+
+@AutoValue
+@DefaultSchema(AutoValueSchema.class)
+public abstract class Column {
+
+  public abstract String getColName();
+
+  public abstract String getColValue();
+
+  public static Builder builder() {
+    return new AutoValue_Column.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setColName(String colName);
+
+    public abstract Builder setColValue(String colValue);
+
+    public abstract Column build();
+  }
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/ComparisonRecord.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/ComparisonRecord.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dto;
+
+import com.google.auto.value.AutoValue;
+import java.util.List;
+import org.apache.beam.sdk.schemas.AutoValueSchema;
+import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+
+@AutoValue
+@DefaultSchema(AutoValueSchema.class)
+public abstract class ComparisonRecord {
+
+  public abstract String getTableName();
+
+  public abstract List<Column> getPrimaryKeyColumns();
+
+  public abstract String getHash();
+
+  public static Builder builder() {
+    return new AutoValue_ComparisonRecord.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setTableName(String tableName);
+
+    public abstract Builder setPrimaryKeyColumns(List<Column> primaryKeyColumns);
+
+    public abstract Builder setHash(String hash);
+
+    public abstract ComparisonRecord build();
+  }
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/MismatchedRecord.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/MismatchedRecord.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dto;
+
+import com.google.auto.value.AutoValue;
+import org.apache.beam.sdk.schemas.AutoValueSchema;
+import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+
+/** Represents a row in the MismatchedRecords table in BigQuery. */
+@AutoValue
+@DefaultSchema(AutoValueSchema.class)
+public abstract class MismatchedRecord {
+  public static final String RUN_ID_COLUMN_NAME = "run_id";
+  public static final String TABLE_NAME_COLUMN_NAME = "table_name";
+  public static final String MISMATCH_TYPE_COLUMN_NAME = "mismatch_type";
+  public static final String RECORD_KEY_COLUMN_NAME = "record_key";
+  public static final String SOURCE_COLUMN_NAME = "source";
+  public static final String HASH_COLUMN_NAME = "hash";
+
+  public abstract String getRunId();
+
+  public abstract String getTableName();
+
+  public abstract String getMismatchType();
+
+  public abstract String getRecordKey();
+
+  public abstract String getSource();
+
+  public abstract String getHash();
+
+  public static Builder builder() {
+    return new AutoValue_MismatchedRecord.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setRunId(String runId);
+
+    public abstract Builder setTableName(String tableName);
+
+    public abstract Builder setMismatchType(String mismatchType);
+
+    public abstract Builder setRecordKey(String recordKey);
+
+    public abstract Builder setSource(String source);
+
+    public abstract Builder setHash(String hash);
+
+    public abstract MismatchedRecord build();
+  }
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/SpannerTableReadConfiguration.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/SpannerTableReadConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dto;
+
+import com.google.auto.value.AutoValue;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.schemas.AutoValueSchema;
+import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+
+@AutoValue
+@DefaultSchema(AutoValueSchema.class)
+public abstract class SpannerTableReadConfiguration {
+
+  public abstract String getTableName();
+
+  @Nullable
+  public abstract List<String> getColumnsToInclude();
+
+  @Nullable
+  public abstract List<String> getColumnsToExclude();
+
+  @Nullable
+  public abstract String getCustomQuery();
+
+  public static Builder builder() {
+    return new AutoValue_SpannerTableReadConfiguration.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setTableName(String tableName);
+
+    public abstract Builder setColumnsToInclude(List<String> columnsToInclude);
+
+    public abstract Builder setColumnsToExclude(List<String> columnsToExclude);
+
+    public abstract Builder setCustomQuery(String customQuery);
+
+    public abstract SpannerTableReadConfiguration build();
+  }
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/TableValidationStats.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/TableValidationStats.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dto;
+
+import com.google.auto.value.AutoValue;
+import org.apache.beam.sdk.schemas.AutoValueSchema;
+import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+import org.joda.time.Instant;
+
+/** Represents a row in the TableValidationStats table in BigQuery. */
+@AutoValue
+@DefaultSchema(AutoValueSchema.class)
+public abstract class TableValidationStats {
+  public static final String RUN_ID_COLUMN_NAME = "run_id";
+  public static final String TABLE_NAME_COLUMN_NAME = "table_name";
+  public static final String STATUS_COLUMN_NAME = "status";
+  public static final String SOURCE_ROW_COUNT_COLUMN_NAME = "source_row_count";
+  public static final String DESTINATION_ROW_COUNT_COLUMN_NAME = "destination_row_count";
+  public static final String MATCHED_ROW_COUNT_COLUMN_NAME = "matched_row_count";
+  public static final String MISMATCH_ROW_COUNT_COLUMN_NAME = "mismatch_row_count";
+  public static final String START_TIMESTAMP_COLUMN_NAME = "start_timestamp";
+  public static final String END_TIMESTAMP_COLUMN_NAME = "end_timestamp";
+
+  public abstract String getRunId();
+
+  public abstract String getTableName();
+
+  public abstract String getStatus();
+
+  public abstract Long getSourceRowCount();
+
+  public abstract Long getDestinationRowCount();
+
+  public abstract Long getMatchedRowCount();
+
+  public abstract Long getMismatchRowCount();
+
+  public abstract Instant getStartTimestamp();
+
+  public abstract Instant getEndTimestamp();
+
+  public static Builder builder() {
+    return new AutoValue_TableValidationStats.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setRunId(String runId);
+
+    public abstract Builder setTableName(String tableName);
+
+    public abstract Builder setStatus(String status);
+
+    public abstract Builder setSourceRowCount(Long sourceRowCount);
+
+    public abstract Builder setDestinationRowCount(Long destinationRowCount);
+
+    public abstract Builder setMatchedRowCount(Long matchedRowCount);
+
+    public abstract Builder setMismatchRowCount(Long mismatchRowCount);
+
+    public abstract Builder setStartTimestamp(Instant startTimestamp);
+
+    public abstract Builder setEndTimestamp(Instant endTimestamp);
+
+    public abstract TableValidationStats build();
+  }
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/ValidationSummary.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/ValidationSummary.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dto;
+
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.schemas.AutoValueSchema;
+import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+import org.joda.time.Instant;
+
+/** Represents a row in the ValidationSummary table in BigQuery. */
+@AutoValue
+@DefaultSchema(AutoValueSchema.class)
+public abstract class ValidationSummary {
+
+  public static final String RUN_ID_COLUMN_NAME = "run_id";
+  public static final String SOURCE_DATABASE_COLUMN_NAME = "source_database";
+  public static final String DESTINATION_DATABASE_COLUMN_NAME = "destination_database";
+  public static final String STATUS_COLUMN_NAME = "status";
+  public static final String TOTAL_TABLES_VALIDATED_COLUMN_NAME = "total_tables_validated";
+  public static final String TABLES_WITH_MISMATCHES_COLUMN_NAME = "tables_with_mismatches";
+  public static final String TOTAL_ROWS_MATCHED_COLUMN_NAME = "total_rows_matched";
+  public static final String TOTAL_ROWS_MISMATCHED_COLUMN_NAME = "total_rows_mismatched";
+  public static final String START_TIMESTAMP_COLUMN_NAME = "start_timestamp";
+  public static final String END_TIMESTAMP_COLUMN_NAME = "end_timestamp";
+
+  public abstract String getRunId();
+
+  @Nullable
+  public abstract String getSourceDatabase();
+
+  @Nullable
+  public abstract String getDestinationDatabase();
+
+  public abstract String getStatus();
+
+  public abstract Long getTotalTablesValidated();
+
+  @Nullable
+  public abstract String getTablesWithMismatches();
+
+  public abstract Long getTotalRowsMatched();
+
+  public abstract Long getTotalRowsMismatched();
+
+  public abstract Instant getStartTimestamp();
+
+  public abstract Instant getEndTimestamp();
+
+  public static Builder builder() {
+    return new AutoValue_ValidationSummary.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setRunId(String runId);
+
+    public abstract Builder setSourceDatabase(String sourceDatabase);
+
+    public abstract Builder setDestinationDatabase(String destinationDatabase);
+
+    public abstract Builder setStatus(String status);
+
+    public abstract Builder setTotalTablesValidated(Long totalTablesValidated);
+
+    public abstract Builder setTablesWithMismatches(String tablesWithMismatches);
+
+    public abstract Builder setTotalRowsMatched(Long totalRowsMatched);
+
+    public abstract Builder setTotalRowsMismatched(Long totalRowsMismatched);
+
+    public abstract Builder setStartTimestamp(Instant startTimestamp);
+
+    public abstract Builder setEndTimestamp(Instant endTimestamp);
+
+    public abstract ValidationSummary build();
+  }
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/ValidationSummaryAccumulator.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/ValidationSummaryAccumulator.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dto;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Accumulator for the custom CombineFn */
+public class ValidationSummaryAccumulator implements Serializable {
+  public long totalTables = 0;
+  public long totalMatched = 0;
+  public long totalMismatched = 0;
+  public List<String> tablesWithMismatches = new ArrayList<>();
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/package-info.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dto;

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/fn/package-info.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/fn/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.fn;

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/mapper/package-info.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/mapper/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/** Google Cloud Teleport templates that process data within Google Cloud. */
+/** Mapper classes for Dataflow Templates. */
+package com.google.cloud.teleport.v2.mapper;

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/templates/package-info.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/templates/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/** Google Cloud Teleport templates that process data within Google Cloud. */
+package com.google.cloud.teleport.v2.templates;

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/transforms/package-info.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/transforms/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/visitor/package-info.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/visitor/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/** Google Cloud Teleport templates that process data within Google Cloud. */
+package com.google.cloud.teleport.v2.visitor;

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -706,6 +706,7 @@
         <module>elasticsearch-common</module>
         <module>file-format-conversion</module>
         <module>gcs-to-sourcedb</module>
+        <module>gcs-spanner-dv</module>
         <module>googlecloud-to-elasticsearch</module>
         <module>googlecloud-to-googlecloud</module>
         <module>googlecloud-to-mongodb</module>


### PR DESCRIPTION
### TL;DR

Added initial structure for a new GCS to Spanner Data Validation template.

### What changed?

Created a new module `gcs-spanner-dv` for validating data between Google Cloud Storage and Spanner. The implementation includes:

- Basic project structure with Maven configuration
- Data model classes for validation records and statistics
- BigQuery schema definitions for storing validation results
- Constants and utility classes for the validation process
- Added the new module to the parent POM

The code includes models for:
- Comparison records between source and destination
- Mismatched record tracking
- Table validation statistics
- Validation summary reporting

### How to test?

The module is currently in initial setup phase with data structures only. No functional implementation to test yet.

When implemented, this template will validate data consistency between GCS files and Spanner tables.

### Why make this change?

This template will provide a data validation solution for customers migrating data from files in GCS to Spanner, allowing them to verify data integrity and consistency between source and destination systems.