### PR TITLE
feat(dv): visitor pattern hashing utilities

### DIFF
--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/visitor/IUnifiedVisitor.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/visitor/IUnifiedVisitor.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.visitor;
+
+import com.google.cloud.Date;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Value;
+import java.math.BigDecimal;
+
+/**
+ * Visitor interface for Spanner {@link Value}s.
+ *
+ * <p>This interface implements the Visitor pattern to decouple the operations performed on Spanner
+ * values (such as hashing or string formatting) from the underlying data structure. This approach
+ * eliminates the need for repetitive {@code switch} statements or type checks across the codebase.
+ */
+public interface IUnifiedVisitor {
+  void visitString(String s);
+
+  void visitInt64(long l);
+
+  void visitFloat64(double d);
+
+  void visitBool(boolean b);
+
+  void visitBytes(byte[] b);
+
+  void visitDate(Date d);
+
+  void visitNumeric(BigDecimal n);
+
+  void visitTimestamp(Timestamp t);
+
+  void visitJson(String j);
+
+  void visitNull();
+
+  void visitDefault(Value v);
+
+  static void dispatch(Value value, IUnifiedVisitor visitor) {
+    if (value.isNull()) {
+      visitor.visitNull();
+      return;
+    }
+
+    switch (value.getType().getCode()) {
+      case STRING -> visitor.visitString(value.getString());
+      case INT64 -> visitor.visitInt64(value.getInt64());
+      case FLOAT64 -> visitor.visitFloat64(value.getFloat64());
+      case BOOL -> visitor.visitBool(value.getBool());
+      case BYTES -> visitor.visitBytes(value.getBytes().toByteArray());
+      case DATE -> visitor.visitDate(value.getDate());
+      case NUMERIC -> visitor.visitNumeric(value.getNumeric());
+      case TIMESTAMP -> visitor.visitTimestamp(value.getTimestamp());
+      case JSON -> visitor.visitJson(value.getJson());
+      default -> visitor.visitDefault(value);
+    }
+  }
+
+  static String formatDate(Date date) {
+    return String.format("%04d-%02d-%02d", date.getYear(), date.getMonth(), date.getDayOfMonth());
+  }
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/visitor/UnifiedHasherVisitor.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/visitor/UnifiedHasherVisitor.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.visitor;
+
+import com.google.cloud.Date;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Value;
+import com.google.common.hash.Hasher;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+
+/** Visitor that hashes Spanner values using a provided {@link Hasher}. */
+public class UnifiedHasherVisitor implements IUnifiedVisitor {
+  private final Hasher hasher;
+
+  public UnifiedHasherVisitor(Hasher hasher) {
+    this.hasher = hasher;
+  }
+
+  @Override
+  public void visitNull() {
+    // Null values are encoded with a sentinel byte 0
+    hasher.putByte((byte) 0);
+  }
+
+  private void markNonNull() {
+    // Non null values are encoded with a sentinel byte 1
+    hasher.putByte((byte) 1);
+  }
+
+  @Override
+  public void visitString(String s) {
+    // String values are encoded with a sentinel byte 1 followed by the length of the string and the
+    // string itself
+    // This is done to avoid collisions with empty strings, null values and string concatenation
+    // across columns.
+    markNonNull();
+    hasher.putInt(s.length());
+    hasher.putString(s, StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public void visitInt64(long l) {
+    // Int64 values are encoded with a sentinel byte 1 followed by the long value
+    markNonNull();
+    hasher.putLong(l);
+  }
+
+  @Override
+  public void visitFloat64(double d) {
+    // Float64 values are encoded with a sentinel byte 1 followed by the double value
+    markNonNull();
+    hasher.putDouble(d);
+  }
+
+  @Override
+  public void visitBool(boolean b) {
+    // Bool values are encoded with a sentinel byte 1 followed by the boolean value
+    markNonNull();
+    hasher.putBoolean(b);
+  }
+
+  @Override
+  public void visitBytes(byte[] b) {
+    // Bytes values are encoded with a sentinel byte 1 followed by the byte array
+    markNonNull();
+    hasher.putBytes(b);
+  }
+
+  @Override
+  public void visitDate(Date d) {
+    // Date values are encoded with a sentinel byte 1 followed by the date in yyyy-MM-dd format
+    markNonNull();
+    hasher.putString(IUnifiedVisitor.formatDate(d), StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public void visitNumeric(BigDecimal n) {
+    // Numeric values are encoded with a sentinel byte 1 followed by the numeric value as a string
+    markNonNull();
+    hasher.putString(n.toString(), StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public void visitTimestamp(Timestamp t) {
+    // Timestamp values are encoded with a sentinel byte 1 followed by the timestamp as a string
+    markNonNull();
+    hasher.putString(t.toString(), StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public void visitJson(String j) {
+    // Json values are encoded with a sentinel byte 1 followed by the json value as a string
+    markNonNull();
+    hasher.putString(j, StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public void visitDefault(Value v) {
+    // Values which are not supported are encoded with a sentinel byte 1 followed by the value as a
+    // string
+    // TODO: Determine if this is the right approach if we should throw an exception here.
+    markNonNull();
+    hasher.putString(v.toString(), StandardCharsets.UTF_8);
+  }
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/visitor/UnifiedStringVisitor.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/visitor/UnifiedStringVisitor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.visitor;
+
+import com.google.cloud.Date;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Value;
+import java.math.BigDecimal;
+import org.apache.commons.codec.binary.Base64;
+
+/** Visitor that converts Spanner values to their String representation. */
+public class UnifiedStringVisitor implements IUnifiedVisitor {
+  private String result;
+
+  public String getResult() {
+    return result;
+  }
+
+  @Override
+  public void visitNull() {
+    result = "";
+  }
+
+  @Override
+  public void visitString(String s) {
+    result = s;
+  }
+
+  @Override
+  public void visitInt64(long l) {
+    result = String.valueOf(l);
+  }
+
+  @Override
+  public void visitFloat64(double d) {
+    result = String.valueOf(d);
+  }
+
+  @Override
+  public void visitBool(boolean b) {
+    result = String.valueOf(b);
+  }
+
+  @Override
+  public void visitBytes(byte[] b) {
+    result = Base64.encodeBase64String(b);
+  }
+
+  @Override
+  public void visitDate(Date d) {
+    result = IUnifiedVisitor.formatDate(d);
+  }
+
+  @Override
+  public void visitNumeric(BigDecimal n) {
+    result = String.valueOf(n);
+  }
+
+  @Override
+  public void visitTimestamp(Timestamp t) {
+    result = t.toString();
+  }
+
+  @Override
+  public void visitJson(String j) {
+    result = j;
+  }
+
+  @Override
+  public void visitDefault(Value v) {
+    result = v.toString();
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/visitor/IUnifiedVisitorTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/visitor/IUnifiedVisitorTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.visitor;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.Date;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Value;
+import java.math.BigDecimal;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class IUnifiedVisitorTest {
+
+  @Test
+  public void testDispatchMatchesString() {
+    IUnifiedVisitor visitor = mock(IUnifiedVisitor.class);
+    String input = "test-string";
+    Value value = Value.string(input);
+
+    IUnifiedVisitor.dispatch(value, visitor);
+
+    verify(visitor).visitString(input);
+  }
+
+  @Test
+  public void testDispatchMatchesInt64() {
+    IUnifiedVisitor visitor = mock(IUnifiedVisitor.class);
+    long input = 123456789L;
+    Value value = Value.int64(input);
+
+    IUnifiedVisitor.dispatch(value, visitor);
+
+    verify(visitor).visitInt64(input);
+  }
+
+  @Test
+  public void testDispatchMatchesFloat64() {
+    IUnifiedVisitor visitor = mock(IUnifiedVisitor.class);
+    double input = 123.456;
+    Value value = Value.float64(input);
+
+    IUnifiedVisitor.dispatch(value, visitor);
+
+    verify(visitor).visitFloat64(input);
+  }
+
+  @Test
+  public void testDispatchMatchesBool() {
+    IUnifiedVisitor visitor = mock(IUnifiedVisitor.class);
+    boolean input = true;
+    Value value = Value.bool(input);
+
+    IUnifiedVisitor.dispatch(value, visitor);
+
+    verify(visitor).visitBool(input);
+  }
+
+  @Test
+  public void testDispatchMatchesBytes() {
+    IUnifiedVisitor visitor = mock(IUnifiedVisitor.class);
+    byte[] input = "test-bytes".getBytes();
+    Value value = Value.bytes(com.google.cloud.ByteArray.copyFrom(input));
+
+    IUnifiedVisitor.dispatch(value, visitor);
+
+    verify(visitor).visitBytes(input);
+  }
+
+  @Test
+  public void testDispatchMatchesDate() {
+    IUnifiedVisitor visitor = mock(IUnifiedVisitor.class);
+    Date input = Date.parseDate("2024-02-06");
+    Value value = Value.date(input);
+
+    IUnifiedVisitor.dispatch(value, visitor);
+
+    verify(visitor).visitDate(input);
+  }
+
+  @Test
+  public void testDispatchMatchesNumeric() {
+    IUnifiedVisitor visitor = mock(IUnifiedVisitor.class);
+    BigDecimal input = new BigDecimal("123.456");
+    Value value = Value.numeric(input);
+
+    IUnifiedVisitor.dispatch(value, visitor);
+
+    verify(visitor).visitNumeric(input);
+  }
+
+  @Test
+  public void testDispatchMatchesTimestamp() {
+    IUnifiedVisitor visitor = mock(IUnifiedVisitor.class);
+    Timestamp input = Timestamp.parseTimestamp("2024-02-06T12:00:00Z");
+    Value value = Value.timestamp(input);
+
+    IUnifiedVisitor.dispatch(value, visitor);
+
+    verify(visitor).visitTimestamp(input);
+  }
+
+  @Test
+  public void testDispatchMatchesJson() {
+    IUnifiedVisitor visitor = mock(IUnifiedVisitor.class);
+    String input = "{\"key\": \"value\"}";
+    Value value = Value.json(input);
+
+    IUnifiedVisitor.dispatch(value, visitor);
+
+    verify(visitor).visitJson(input);
+  }
+
+  @Test
+  public void testDispatchMatchesNull() {
+    IUnifiedVisitor visitor = mock(IUnifiedVisitor.class);
+    Value value = Value.string(null);
+
+    IUnifiedVisitor.dispatch(value, visitor);
+
+    verify(visitor).visitNull();
+  }
+
+  @Test
+  public void testDispatchMatchesDefault() {
+    IUnifiedVisitor visitor = mock(IUnifiedVisitor.class);
+    // STRUCT is not explicitly handled in the switch case, so it should go to
+    // default
+    Value value = Value.struct(com.google.cloud.spanner.Struct.newBuilder().build());
+
+    IUnifiedVisitor.dispatch(value, visitor);
+
+    verify(visitor).visitDefault(value);
+  }
+
+  @Test
+  public void testFormatDate() {
+    Date date = Date.fromYearMonthDay(2024, 2, 6);
+    String formatted = IUnifiedVisitor.formatDate(date);
+    assertEquals("2024-02-06", formatted);
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/visitor/UnifiedHasherVisitorTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/visitor/UnifiedHasherVisitorTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.visitor;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+import com.google.cloud.Date;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Value;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import java.math.BigDecimal;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class UnifiedHasherVisitorTest {
+
+  @Test
+  public void testVisitString() {
+    Hasher hasher = Hashing.murmur3_128().newHasher();
+    UnifiedHasherVisitor visitor = new UnifiedHasherVisitor(hasher);
+    String input = "test-string";
+
+    visitor.visitString(input);
+    HashCode actualHash = hasher.hash();
+
+    HashCode expectedHash =
+        Hashing.murmur3_128()
+            .newHasher()
+            .putByte((byte) 1)
+            .putInt(input.length())
+            .putString(input, UTF_8)
+            .hash();
+
+    assertEquals(expectedHash, actualHash);
+  }
+
+  @Test
+  public void testVisitInt64() {
+    Hasher hasher = Hashing.murmur3_128().newHasher();
+    UnifiedHasherVisitor visitor = new UnifiedHasherVisitor(hasher);
+    long input = 123456789L;
+
+    visitor.visitInt64(input);
+    HashCode actualHash = hasher.hash();
+
+    HashCode expectedHash =
+        Hashing.murmur3_128().newHasher().putByte((byte) 1).putLong(input).hash();
+
+    assertEquals(expectedHash, actualHash);
+  }
+
+  @Test
+  public void testVisitFloat64() {
+    Hasher hasher = Hashing.murmur3_128().newHasher();
+    UnifiedHasherVisitor visitor = new UnifiedHasherVisitor(hasher);
+    double input = 123.456;
+
+    visitor.visitFloat64(input);
+    HashCode actualHash = hasher.hash();
+
+    HashCode expectedHash =
+        Hashing.murmur3_128().newHasher().putByte((byte) 1).putDouble(input).hash();
+
+    assertEquals(expectedHash, actualHash);
+  }
+
+  @Test
+  public void testVisitBool() {
+    Hasher hasher = Hashing.murmur3_128().newHasher();
+    UnifiedHasherVisitor visitor = new UnifiedHasherVisitor(hasher);
+    boolean input = true;
+
+    visitor.visitBool(input);
+    HashCode actualHash = hasher.hash();
+
+    HashCode expectedHash =
+        Hashing.murmur3_128().newHasher().putByte((byte) 1).putBoolean(input).hash();
+
+    assertEquals(expectedHash, actualHash);
+  }
+
+  @Test
+  public void testVisitBytes() {
+    Hasher hasher = Hashing.murmur3_128().newHasher();
+    UnifiedHasherVisitor visitor = new UnifiedHasherVisitor(hasher);
+    byte[] input = "test-bytes".getBytes(UTF_8);
+
+    visitor.visitBytes(input);
+    HashCode actualHash = hasher.hash();
+
+    HashCode expectedHash =
+        Hashing.murmur3_128().newHasher().putByte((byte) 1).putBytes(input).hash();
+
+    assertEquals(expectedHash, actualHash);
+  }
+
+  @Test
+  public void testVisitDate() {
+    Hasher hasher = Hashing.murmur3_128().newHasher();
+    UnifiedHasherVisitor visitor = new UnifiedHasherVisitor(hasher);
+    Date input = Date.parseDate("2024-02-06");
+
+    visitor.visitDate(input);
+    HashCode actualHash = hasher.hash();
+
+    HashCode expectedHash =
+        Hashing.murmur3_128().newHasher().putByte((byte) 1).putString("2024-02-06", UTF_8).hash();
+
+    assertEquals(expectedHash, actualHash);
+  }
+
+  @Test
+  public void testVisitNumeric() {
+    Hasher hasher = Hashing.murmur3_128().newHasher();
+    UnifiedHasherVisitor visitor = new UnifiedHasherVisitor(hasher);
+    BigDecimal input = new BigDecimal("123.456");
+
+    visitor.visitNumeric(input);
+    HashCode actualHash = hasher.hash();
+
+    HashCode expectedHash =
+        Hashing.murmur3_128()
+            .newHasher()
+            .putByte((byte) 1)
+            .putString(input.toString(), UTF_8)
+            .hash();
+
+    assertEquals(expectedHash, actualHash);
+  }
+
+  @Test
+  public void testVisitTimestamp() {
+    Hasher hasher = Hashing.murmur3_128().newHasher();
+    UnifiedHasherVisitor visitor = new UnifiedHasherVisitor(hasher);
+    Timestamp input = Timestamp.parseTimestamp("2024-02-06T12:00:00Z");
+
+    visitor.visitTimestamp(input);
+    HashCode actualHash = hasher.hash();
+
+    HashCode expectedHash =
+        Hashing.murmur3_128()
+            .newHasher()
+            .putByte((byte) 1)
+            .putString(input.toString(), UTF_8)
+            .hash();
+
+    assertEquals(expectedHash, actualHash);
+  }
+
+  @Test
+  public void testVisitJson() {
+    Hasher hasher = Hashing.murmur3_128().newHasher();
+    UnifiedHasherVisitor visitor = new UnifiedHasherVisitor(hasher);
+    String input = "{\"key\": \"value\"}";
+
+    visitor.visitJson(input);
+    HashCode actualHash = hasher.hash();
+
+    HashCode expectedHash =
+        Hashing.murmur3_128().newHasher().putByte((byte) 1).putString(input, UTF_8).hash();
+
+    assertEquals(expectedHash, actualHash);
+  }
+
+  @Test
+  public void testVisitNull() {
+    Hasher hasher = Hashing.murmur3_128().newHasher();
+    UnifiedHasherVisitor visitor = new UnifiedHasherVisitor(hasher);
+
+    visitor.visitNull();
+    HashCode actualHash = hasher.hash();
+
+    HashCode expectedHash = Hashing.murmur3_128().newHasher().putByte((byte) 0).hash();
+
+    assertEquals(expectedHash, actualHash);
+  }
+
+  @Test
+  public void testVisitDefault() {
+    Hasher hasher = Hashing.murmur3_128().newHasher();
+    UnifiedHasherVisitor visitor = new UnifiedHasherVisitor(hasher);
+    Value input = Value.string("default-value");
+
+    visitor.visitDefault(input);
+    HashCode actualHash = hasher.hash();
+
+    HashCode expectedHash =
+        Hashing.murmur3_128()
+            .newHasher()
+            .putByte((byte) 1)
+            .putString(input.toString(), UTF_8)
+            .hash();
+
+    assertEquals(expectedHash, actualHash);
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/visitor/UnifiedStringVisitorTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/visitor/UnifiedStringVisitorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.visitor;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.cloud.Date;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Value;
+import java.math.BigDecimal;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class UnifiedStringVisitorTest {
+
+  @Test
+  public void testVisitString() {
+    UnifiedStringVisitor visitor = new UnifiedStringVisitor();
+    String input = "test-string";
+
+    visitor.visitString(input);
+
+    assertEquals(input, visitor.getResult());
+  }
+
+  @Test
+  public void testVisitInt64() {
+    UnifiedStringVisitor visitor = new UnifiedStringVisitor();
+    long input = 123456789L;
+
+    visitor.visitInt64(input);
+
+    assertEquals(String.valueOf(input), visitor.getResult());
+  }
+
+  @Test
+  public void testVisitFloat64() {
+    UnifiedStringVisitor visitor = new UnifiedStringVisitor();
+    double input = 123.456;
+
+    visitor.visitFloat64(input);
+
+    assertEquals(String.valueOf(input), visitor.getResult());
+  }
+
+  @Test
+  public void testVisitBool() {
+    UnifiedStringVisitor visitor = new UnifiedStringVisitor();
+    boolean input = true;
+
+    visitor.visitBool(input);
+
+    assertEquals(String.valueOf(input), visitor.getResult());
+  }
+
+  @Test
+  public void testVisitBytes() {
+    UnifiedStringVisitor visitor = new UnifiedStringVisitor();
+    byte[] input = "test-bytes".getBytes();
+
+    visitor.visitBytes(input);
+
+    assertEquals(Base64.encodeBase64String(input), visitor.getResult());
+  }
+
+  @Test
+  public void testVisitDate() {
+    UnifiedStringVisitor visitor = new UnifiedStringVisitor();
+    Date input = Date.parseDate("2024-02-06");
+
+    visitor.visitDate(input);
+
+    assertEquals("2024-02-06", visitor.getResult());
+  }
+
+  @Test
+  public void testVisitNumeric() {
+    UnifiedStringVisitor visitor = new UnifiedStringVisitor();
+    BigDecimal input = new BigDecimal("123.456");
+
+    visitor.visitNumeric(input);
+
+    assertEquals(String.valueOf(input), visitor.getResult());
+  }
+
+  @Test
+  public void testVisitTimestamp() {
+    UnifiedStringVisitor visitor = new UnifiedStringVisitor();
+    Timestamp input = Timestamp.parseTimestamp("2024-02-06T12:00:00Z");
+
+    visitor.visitTimestamp(input);
+
+    assertEquals(input.toString(), visitor.getResult());
+  }
+
+  @Test
+  public void testVisitJson() {
+    UnifiedStringVisitor visitor = new UnifiedStringVisitor();
+    String input = "{\"key\": \"value\"}";
+
+    visitor.visitJson(input);
+
+    assertEquals(input, visitor.getResult());
+  }
+
+  @Test
+  public void testVisitNull() {
+    UnifiedStringVisitor visitor = new UnifiedStringVisitor();
+
+    visitor.visitNull();
+
+    assertEquals("", visitor.getResult());
+  }
+
+  @Test
+  public void testVisitDefault() {
+    UnifiedStringVisitor visitor = new UnifiedStringVisitor();
+    Value input = Value.string("default-value");
+
+    visitor.visitDefault(input);
+
+    assertEquals(input.toString(), visitor.getResult());
+  }
+}


### PR DESCRIPTION
### TL;DR

Implemented a Visitor pattern for Spanner Value types to improve code maintainability and reduce duplication.

### What changed?

Added three new classes to implement the Visitor pattern for Spanner Value types:

1. `IUnifiedVisitor` - Interface defining visit methods for each Spanner data type with a static dispatch method to route values to the appropriate visitor method.

2. `UnifiedHasherVisitor` - Implementation that hashes Spanner values using a provided Hasher, with careful handling of null values and type-specific encoding.

3. `UnifiedStringVisitor` - Implementation that converts Spanner values to their string representation.

Added comprehensive unit tests for both visitor implementations to verify correct behavior for all Spanner data types.

### How to test?

Added tests for the Visitor classes.

1. `UnifiedHasherVisitorTest` - Tests the hashing logic.
2. `UnifiedStringVisitorTest` - Tests the string conversion logic.