### PR TITLE
feat(dv): schema mappers and validation combiners

### DIFF
--- a/v2/gcs-spanner-dv/pom.xml
+++ b/v2/gcs-spanner-dv/pom.xml
@@ -69,4 +69,23 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <!-- Jacoco configuration -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+         <version>${jacoco.version}</version>
+        <configuration>
+          <excludes combine.children="append">
+            <!-- combine.children appends to the existing exclusions in the
+             parent POM(s). -->
+            <exclude>com/google/cloud/teleport/v2/dto/**</exclude>
+            <exclude>com/google/cloud/teleport/v2/constants/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/constants/GCSSpannerDVConstants.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/constants/GCSSpannerDVConstants.java
@@ -27,4 +27,6 @@ public class GCSSpannerDVConstants {
       new TupleTag<ComparisonRecord>() {};
   public static final TupleTag<ComparisonRecord> MISSING_IN_SOURCE_TAG =
       new TupleTag<ComparisonRecord>() {};
+
+  public static final String TABLE_NAME_COLUMN = "__tableName__";
 }

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/MismatchedRecord.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/MismatchedRecord.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.dto;
 
 import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.schemas.AutoValueSchema;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 
@@ -33,6 +34,7 @@ public abstract class MismatchedRecord {
 
   public abstract String getRunId();
 
+  @Nullable
   public abstract String getSchemaName();
 
   public abstract String getTableName();

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/TableValidationStats.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/TableValidationStats.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.dto;
 
 import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.schemas.AutoValueSchema;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.joda.time.Instant;
@@ -37,6 +38,7 @@ public abstract class TableValidationStats {
 
   public abstract String getRunId();
 
+  @Nullable
   public abstract String getSchemaName();
 
   public abstract String getTableName();

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/fn/IdentityGenericRecordFn.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/fn/IdentityGenericRecordFn.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.fn;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+
+/**
+ * A {@link SerializableFunction} that returns the input {@link GenericRecord} as is.
+ *
+ * <p>This is used to allow {@link org.apache.beam.sdk.extensions.avro.io.AvroIO} to parse
+ * GenericRecords while deferring the coder inference/setting to a later stage (e.g. explicitly
+ * setting {@link com.google.cloud.teleport.v2.coders.GenericRecordCoder}).
+ */
+public class IdentityGenericRecordFn implements SerializableFunction<GenericRecord, GenericRecord> {
+  @Override
+  public GenericRecord apply(GenericRecord input) {
+    return input;
+  }
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/fn/SchemaMapperProviderFn.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/fn/SchemaMapperProviderFn.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.fn;
+
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.IdentityMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SchemaFileOverridesBasedMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SchemaStringOverridesBasedMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SessionBasedMapper;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link SerializableFunction} that provides an {@link ISchemaMapper} given a {@link Ddl}. This
+ * class encapsulates the logic for constructing the schema mapper, including handling schema
+ * overrides.
+ */
+public class SchemaMapperProviderFn implements SerializableFunction<Ddl, ISchemaMapper> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SchemaMapperProviderFn.class);
+
+  private final String sessionFilePath;
+  private final String schemaOverridesFilePath;
+  private final String tableOverrides;
+  private final String columnOverrides;
+
+  public SchemaMapperProviderFn(
+      String sessionFilePath,
+      String schemaOverridesFilePath,
+      String tableOverrides,
+      String columnOverrides) {
+    this.sessionFilePath = sessionFilePath;
+    this.schemaOverridesFilePath = schemaOverridesFilePath;
+    this.tableOverrides = tableOverrides;
+    this.columnOverrides = columnOverrides;
+  }
+
+  @Override
+  public ISchemaMapper apply(Ddl ddl) {
+    Map<String, String> schemaStringOverrides = new HashMap<>();
+    if (tableOverrides != null && !tableOverrides.isEmpty()) {
+      schemaStringOverrides.put("tableOverrides", tableOverrides);
+    }
+    if (columnOverrides != null && !columnOverrides.isEmpty()) {
+      schemaStringOverrides.put("columnOverrides", columnOverrides);
+    }
+
+    return getSchemaMapper(sessionFilePath, schemaOverridesFilePath, schemaStringOverrides, ddl);
+  }
+
+  private ISchemaMapper getSchemaMapper(
+      String sessionFilePath,
+      String schemaOverridesFilePath,
+      Map<String, String> schemaStringOverrides,
+      Ddl ddl) {
+    if (sessionFilePath != null && !sessionFilePath.isEmpty()) {
+      LOG.info("Using SessionBasedMapper with file: {}", sessionFilePath);
+      return new SessionBasedMapper(sessionFilePath, ddl);
+    } else if (schemaOverridesFilePath != null && !schemaOverridesFilePath.isEmpty()) {
+      LOG.info("Using SchemaFileOverridesBasedMapper with file: {}", schemaOverridesFilePath);
+      return new SchemaFileOverridesBasedMapper(schemaOverridesFilePath, ddl);
+    } else if (schemaStringOverrides != null && !schemaStringOverrides.isEmpty()) {
+      LOG.info("Using SchemaStringOverridesBasedMapper with overrides: {}", schemaStringOverrides);
+      return new SchemaStringOverridesBasedMapper(schemaStringOverrides, ddl);
+    } else {
+      LOG.info("Using IdentityMapper");
+      return new IdentityMapper(ddl);
+    }
+  }
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/fn/ValidationSummaryCombineFn.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/fn/ValidationSummaryCombineFn.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.fn;
+
+import com.google.cloud.teleport.v2.dto.TableValidationStats;
+import com.google.cloud.teleport.v2.dto.ValidationSummary;
+import com.google.cloud.teleport.v2.dto.ValidationSummaryAccumulator;
+import org.apache.beam.sdk.transforms.Combine;
+import org.joda.time.Instant;
+
+/**
+ * A {@link Combine.CombineFn} that aggregates individual {@link TableValidationStats} into a single
+ * global {@link ValidationSummary}.
+ *
+ * <p>In Apache Beam, a {@link Combine.CombineFn} is used to perform associative and commutative
+ * aggregations on a {@link org.apache.beam.sdk.values.PCollection}. It works by distributing the
+ * aggregation across multiple workers:
+ *
+ * <ol>
+ *   <li><b>Create Accumulator:</b> Initializes a new mutable accumulator ({@link
+ *       ValidationSummaryAccumulator}).
+ *   <li><b>Add Input:</b> Adds a single {@link TableValidationStats} input to the accumulator.
+ *   <li><b>Merge Accumulators:</b> Merges multiple accumulators (potentially from different
+ *       workers) into one.
+ *   <li><b>Extract Output:</b> Produces the final {@link ValidationSummary} from the merged
+ *       accumulator.
+ * </ol>
+ *
+ * <p>This specific implementation aggregates validation results by:
+ *
+ * <ul>
+ *   <li>Summing up total matched and mismatched row counts across all tables.
+ *   <li>Collecting a list of tables that contain mismatches (joined as a string).
+ *   <li>Determining the overall validation status ("MATCH" if zero mismatches, otherwise
+ *       "MISMATCH").
+ *   <li>Populating metadata such as Run ID, source/destination database names, and timestamps.
+ * </ul>
+ */
+public class ValidationSummaryCombineFn
+    extends Combine.CombineFn<
+        TableValidationStats, ValidationSummaryAccumulator, ValidationSummary> {
+
+  private final String runId;
+  private final Instant startTimestamp;
+  private final String sourceDatabase;
+  private final String destinationDatabase;
+
+  public ValidationSummaryCombineFn(
+      String runId, Instant startTimestamp, String sourceDatabase, String destinationDatabase) {
+    this.runId = runId;
+    this.startTimestamp = startTimestamp;
+    this.sourceDatabase = sourceDatabase;
+    this.destinationDatabase = destinationDatabase;
+  }
+
+  @Override
+  public ValidationSummaryAccumulator createAccumulator() {
+    return new ValidationSummaryAccumulator();
+  }
+
+  @Override
+  public ValidationSummaryAccumulator addInput(
+      ValidationSummaryAccumulator accumulator, TableValidationStats input) {
+    accumulator.totalTables++;
+    accumulator.totalMatched += input.getMatchedRowCount();
+    accumulator.totalMismatched += input.getMismatchRowCount();
+    if (input.getMismatchRowCount() > 0) {
+      accumulator.tablesWithMismatches.add(input.getTableName());
+    }
+    return accumulator;
+  }
+
+  @Override
+  public ValidationSummaryAccumulator mergeAccumulators(
+      Iterable<ValidationSummaryAccumulator> accumulators) {
+    ValidationSummaryAccumulator merged = new ValidationSummaryAccumulator();
+    for (ValidationSummaryAccumulator acc : accumulators) {
+      merged.totalTables += acc.totalTables;
+      merged.totalMatched += acc.totalMatched;
+      merged.totalMismatched += acc.totalMismatched;
+      merged.tablesWithMismatches.addAll(acc.tablesWithMismatches);
+    }
+    return merged;
+  }
+
+  @Override
+  public ValidationSummary extractOutput(ValidationSummaryAccumulator accumulator) {
+    String status = accumulator.totalMismatched == 0 ? "MATCH" : "MISMATCH";
+    return ValidationSummary.builder()
+        .setRunId(runId)
+        .setSourceDatabase(sourceDatabase)
+        .setDestinationDatabase(destinationDatabase)
+        .setStatus(status)
+        .setTotalTablesValidated(accumulator.totalTables)
+        .setTablesWithMismatches(String.join(",", accumulator.tablesWithMismatches))
+        .setTotalRowsMatched(accumulator.totalMatched)
+        .setTotalRowsMismatched(accumulator.totalMismatched)
+        .setStartTimestamp(startTimestamp)
+        .setEndTimestamp(Instant.now())
+        .build();
+  }
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapper.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapper.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.mapper;
 
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Value;
+import com.google.cloud.teleport.v2.constants.GCSSpannerDVConstants;
 import com.google.cloud.teleport.v2.dto.Column;
 import com.google.cloud.teleport.v2.dto.ComparisonRecord;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
@@ -89,10 +90,10 @@ public class ComparisonRecordMapper implements Serializable {
   public ComparisonRecord mapFrom(Struct spannerStruct) {
     TreeMap<String, Value> values = new TreeMap<>();
     spannerStruct.getType().getStructFields().stream()
-        .filter(field -> !field.getName().equals("__tableName__"))
+        .filter(field -> !field.getName().equals(GCSSpannerDVConstants.TABLE_NAME_COLUMN))
         .forEach(field -> values.put(field.getName(), spannerStruct.getValue(field.getName())));
 
-    String tableName = spannerStruct.getString("__tableName__");
+    String tableName = spannerStruct.getString(GCSSpannerDVConstants.TABLE_NAME_COLUMN);
     Table table = ddl.table(tableName);
     if (table == null) {
       throw new RuntimeException("Table not found in DDL: " + tableName);

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapper.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapper.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.mapper;
+
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Value;
+import com.google.cloud.teleport.v2.dto.Column;
+import com.google.cloud.teleport.v2.dto.ComparisonRecord;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.migrations.avro.GenericRecordTypeConvertor;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
+import com.google.cloud.teleport.v2.spanner.utils.ISpannerMigrationTransformer;
+import com.google.cloud.teleport.v2.visitor.IUnifiedVisitor;
+import com.google.cloud.teleport.v2.visitor.UnifiedHasherVisitor;
+import com.google.cloud.teleport.v2.visitor.UnifiedStringVisitor;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import org.apache.avro.generic.GenericRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Mapper class to convert various inputs into a {@link ComparisonRecord}. It handles the logic of
+ * extracting data, converting types, and computing hashes.
+ */
+public class ComparisonRecordMapper implements Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ComparisonRecordMapper.class);
+  private final ISchemaMapper schemaMapper;
+  private final ISpannerMigrationTransformer transformer;
+  private final Ddl ddl;
+
+  public ComparisonRecordMapper(
+      ISchemaMapper schemaMapper, ISpannerMigrationTransformer transformer, Ddl ddl) {
+    this.schemaMapper = schemaMapper;
+    this.transformer = transformer;
+    this.ddl = ddl;
+  }
+
+  public ComparisonRecord mapFrom(GenericRecord avroRecord) {
+    try {
+      String tableName = avroRecord.get("tableName").toString();
+      String shardId =
+          avroRecord.get("shardId") != null ? avroRecord.get("shardId").toString() : "";
+      GenericRecord payload = (GenericRecord) avroRecord.get("payload");
+      GenericRecordTypeConvertor convertor =
+          new GenericRecordTypeConvertor(schemaMapper, "", shardId, transformer);
+      Map<String, Value> values = convertor.transformChangeEvent(payload, tableName);
+
+      if (values == null) {
+        return null;
+      }
+      // Map to Spanner table using mapper
+      String spannerTableName = schemaMapper.getSpannerTableName("", tableName);
+      Table table = ddl.table(spannerTableName);
+      if (table == null) {
+        throw new RuntimeException("Table not found in DDL: " + spannerTableName);
+      }
+      List<String> pkNames =
+          table.primaryKeys().stream().map(IndexColumn::name).collect(Collectors.toList());
+      return buildRecord(spannerTableName, new TreeMap<>(values), pkNames);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Error mapping GenericRecord to ComparisonRecord: " + e.getMessage(), e);
+    }
+  }
+
+  public ComparisonRecord mapFrom(Struct spannerStruct) {
+    TreeMap<String, Value> values = new TreeMap<>();
+    spannerStruct.getType().getStructFields().stream()
+        .filter(field -> !field.getName().equals("__tableName__"))
+        .forEach(field -> values.put(field.getName(), spannerStruct.getValue(field.getName())));
+
+    String tableName = spannerStruct.getString("__tableName__");
+    Table table = ddl.table(tableName);
+    if (table == null) {
+      throw new RuntimeException("Table not found in DDL: " + tableName);
+    }
+    List<String> pkNames =
+        table.primaryKeys().stream().map(IndexColumn::name).collect(Collectors.toList());
+
+    return buildRecord(tableName, values, pkNames);
+  }
+
+  /**
+   * Builds the {@link ComparisonRecord} from the mapped data.
+   *
+   * <p><b>1. Strict Ordering with TreeMap:</b><br>
+   * A {@link TreeMap} is used to store the data before hashing. This ensures that the keys (column
+   * names) are always processed in their natural order (alphabetical). This is critical for
+   * deterministic hashing; regardless of the order in which columns appear in the input source
+   * (Avro or Spanner), the resulting hash must be identical for the same record content.
+   *
+   * <p><b>2. Type-Aware Hashing:</b><br>
+   * This implementation uses a {@link UnifiedHasherVisitor} to perform type-aware hashing. Instead
+   * of converting everything to strings (which risks collisions, e.g., "123" vs 123), specific
+   * types are hashed with unique prefixes (sentinels). This ensures that a string "true" has a
+   * different hash from a boolean {@code true}, enhancing collision resistance.
+   *
+   * <p><b>3. Murmur3 128-bit Hash:</b><br>
+   * We use Murmur3 128-bit hashing. The 128-bit has a one in a quadrillion probability of collision
+   * in a dataset of size 2.6 trillion. This provides scale assurance for most practical workloads.
+   * 128 bit is also small enough for Dataflow's shuffle and GBK operations to be highly efficient
+   * on.
+   */
+  private ComparisonRecord buildRecord(
+      String tableName, TreeMap<String, Value> data, List<String> pkNames) {
+
+    // 1. Use the record data to compute the hash
+    Hasher hasher = Hashing.murmur3_128().newHasher();
+    UnifiedHasherVisitor hasherVisitor = new UnifiedHasherVisitor(hasher);
+    for (Map.Entry<String, Value> entry : data.entrySet()) {
+      // Hash the columnNames
+      hasher.putString(entry.getKey(), StandardCharsets.UTF_8);
+      // Hash the columnValues
+      IUnifiedVisitor.dispatch(entry.getValue(), hasherVisitor);
+    }
+    // Add the tableName to the hasher at the end
+    hasher.putString(tableName, StandardCharsets.UTF_8);
+    String hash = hasher.hash().toString();
+
+    // 2. Use the pk column names to form the full primary keys from the record data
+    UnifiedStringVisitor stringVisitor = new UnifiedStringVisitor();
+    List<Column> primaryKeyColumns =
+        pkNames.stream()
+            .map(
+                pkName -> {
+                  Value val = data.get(pkName);
+                  IUnifiedVisitor.dispatch(val, stringVisitor);
+                  return Column.builder()
+                      .setColName(pkName)
+                      .setColValue(stringVisitor.getResult())
+                      .build();
+                })
+            .collect(Collectors.toList());
+
+    // 3. Build the final record
+    return ComparisonRecord.builder()
+        .setTableName(tableName)
+        .setHash(hash)
+        .setPrimaryKeyColumns(primaryKeyColumns)
+        .build();
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/fn/IdentityGenericRecordFnTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/fn/IdentityGenericRecordFnTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.fn;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class IdentityGenericRecordFnTest {
+
+  @Test
+  public void testApply() {
+    IdentityGenericRecordFn fn = new IdentityGenericRecordFn();
+    GenericRecord input = mock(GenericRecord.class);
+    assertEquals(input, fn.apply(input));
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/fn/SchemaMapperProviderFnTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/fn/SchemaMapperProviderFnTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.fn;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.IdentityMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SchemaFileOverridesBasedMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SchemaStringOverridesBasedMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SessionBasedMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SchemaMapperProviderFnTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void testGetSchemaMapper_SessionFile() throws IOException {
+    Path sessionFile = temporaryFolder.newFile("session.json").toPath();
+    Files.write(
+        sessionFile, "{\"SpSchema\": {}, \"SrcSchema\": {}, \"SyntheticPKeys\": {}}".getBytes());
+    Ddl ddl = mock(Ddl.class);
+
+    SchemaMapperProviderFn fn =
+        new SchemaMapperProviderFn(sessionFile.toString(), null, null, null);
+    ISchemaMapper mapper = fn.apply(ddl);
+
+    assertTrue(mapper instanceof SessionBasedMapper);
+  }
+
+  @Test
+  public void testGetSchemaMapper_SchemaOverridesFile() throws IOException {
+    Path overridesFile = temporaryFolder.newFile("overrides.json").toPath();
+    Files.write(overridesFile, "{}".getBytes());
+    Ddl ddl = mock(Ddl.class);
+
+    SchemaMapperProviderFn fn =
+        new SchemaMapperProviderFn(null, overridesFile.toString(), null, null);
+    ISchemaMapper mapper = fn.apply(ddl);
+
+    assertTrue(mapper instanceof SchemaFileOverridesBasedMapper);
+  }
+
+  @Test
+  public void testGetSchemaMapper_StringOverrides() {
+    Ddl ddl = mock(Ddl.class);
+    String tableOverrides = "{{old_table, new_table}}";
+
+    SchemaMapperProviderFn fn = new SchemaMapperProviderFn(null, null, tableOverrides, null);
+    ISchemaMapper mapper = fn.apply(ddl);
+
+    assertTrue(mapper instanceof SchemaStringOverridesBasedMapper);
+  }
+
+  @Test
+  public void testGetSchemaMapper_ColumnOverrides() {
+    Ddl ddl = mock(Ddl.class);
+    String columnOverrides = "{\"col1\": \"newCol1\"}";
+
+    SchemaMapperProviderFn fn = new SchemaMapperProviderFn(null, null, null, columnOverrides);
+    ISchemaMapper mapper = fn.apply(ddl);
+
+    assertTrue(mapper instanceof SchemaStringOverridesBasedMapper);
+  }
+
+  @Test
+  public void testGetSchemaMapper_BothStringOverrides() {
+    Ddl ddl = mock(Ddl.class);
+    String tableOverrides = "{{old_table, new_table}}";
+    String columnOverrides = "{\"col1\": \"newCol1\"}";
+
+    SchemaMapperProviderFn fn =
+        new SchemaMapperProviderFn(null, null, tableOverrides, columnOverrides);
+    ISchemaMapper mapper = fn.apply(ddl);
+
+    assertTrue(mapper instanceof SchemaStringOverridesBasedMapper);
+  }
+
+  @Test
+  public void testGetSchemaMapper_SessionFilePriority() throws IOException {
+    Path sessionFile = temporaryFolder.newFile("session_prio.json").toPath();
+    Files.write(
+        sessionFile, "{\"SpSchema\": {}, \"SrcSchema\": {}, \"SyntheticPKeys\": {}}".getBytes());
+    Path overridesFile = temporaryFolder.newFile("overrides_ignored.json").toPath();
+    Files.write(overridesFile, "{}".getBytes());
+    Ddl ddl = mock(Ddl.class);
+
+    SchemaMapperProviderFn fn =
+        new SchemaMapperProviderFn(
+            sessionFile.toString(), overridesFile.toString(), "{{old, new}}", null);
+    ISchemaMapper mapper = fn.apply(ddl);
+
+    assertTrue(mapper instanceof SessionBasedMapper);
+  }
+
+  @Test
+  public void testGetSchemaMapper_FileOverridesPriority() throws IOException {
+    Path overridesFile = temporaryFolder.newFile("overrides_prio.json").toPath();
+    Files.write(overridesFile, "{}".getBytes());
+    Ddl ddl = mock(Ddl.class);
+
+    SchemaMapperProviderFn fn =
+        new SchemaMapperProviderFn(null, overridesFile.toString(), "{{old, new}}", null);
+    ISchemaMapper mapper = fn.apply(ddl);
+
+    assertTrue(mapper instanceof SchemaFileOverridesBasedMapper);
+  }
+
+  @Test
+  public void testGetSchemaMapper_EmptyStrings() {
+    Ddl ddl = mock(Ddl.class);
+
+    SchemaMapperProviderFn fn = new SchemaMapperProviderFn("", "", "", "");
+    ISchemaMapper mapper = fn.apply(ddl);
+
+    assertTrue(mapper instanceof IdentityMapper);
+  }
+
+  @Test
+  public void testGetSchemaMapper_Identity() {
+    Ddl ddl = mock(Ddl.class);
+
+    SchemaMapperProviderFn fn = new SchemaMapperProviderFn(null, null, null, null);
+    ISchemaMapper mapper = fn.apply(ddl);
+
+    assertTrue(mapper instanceof IdentityMapper);
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/fn/ValidationSummaryCombineFnTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/fn/ValidationSummaryCombineFnTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.fn;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.teleport.v2.dto.TableValidationStats;
+import com.google.cloud.teleport.v2.dto.ValidationSummary;
+import com.google.cloud.teleport.v2.dto.ValidationSummaryAccumulator;
+import java.util.Arrays;
+import org.joda.time.Instant;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ValidationSummaryCombineFnTest {
+
+  @Test
+  public void testCreateAccumulator() {
+    ValidationSummaryCombineFn fn =
+        new ValidationSummaryCombineFn("run1", Instant.now(), "src", "dst");
+    ValidationSummaryAccumulator acc = fn.createAccumulator();
+    assertEquals(0L, acc.totalTables);
+    assertEquals(0L, acc.totalMatched);
+    assertEquals(0L, acc.totalMismatched);
+    assertTrue(acc.tablesWithMismatches.isEmpty());
+  }
+
+  @Test
+  public void testAddInput() {
+    ValidationSummaryCombineFn fn =
+        new ValidationSummaryCombineFn("run1", Instant.now(), "src", "dst");
+    ValidationSummaryAccumulator acc = fn.createAccumulator();
+
+    TableValidationStats stats =
+        TableValidationStats.builder()
+            .setTableName("table1")
+            .setMatchedRowCount(100L)
+            .setMismatchRowCount(5L)
+            .setRunId("run1")
+            .setStatus("status")
+            .setSourceRowCount(105L)
+            .setDestinationRowCount(105L)
+            .setStartTimestamp(Instant.now())
+            .setEndTimestamp(Instant.now())
+            .build();
+
+    fn.addInput(acc, stats);
+
+    assertEquals(1L, acc.totalTables);
+    assertEquals(100L, acc.totalMatched);
+    assertEquals(5L, acc.totalMismatched);
+    assertTrue(acc.tablesWithMismatches.contains("table1"));
+  }
+
+  @Test
+  public void testMergeAccumulators() {
+    ValidationSummaryCombineFn fn =
+        new ValidationSummaryCombineFn("run1", Instant.now(), "src", "dst");
+
+    ValidationSummaryAccumulator acc1 = new ValidationSummaryAccumulator();
+    acc1.totalTables = 1;
+    acc1.totalMatched = 10;
+    acc1.totalMismatched = 2;
+    acc1.tablesWithMismatches.add("t1");
+
+    ValidationSummaryAccumulator acc2 = new ValidationSummaryAccumulator();
+    acc2.totalTables = 1;
+    acc2.totalMatched = 20;
+    acc2.totalMismatched = 0;
+
+    ValidationSummaryAccumulator merged = fn.mergeAccumulators(Arrays.asList(acc1, acc2));
+
+    assertEquals(2L, merged.totalTables);
+    assertEquals(30L, merged.totalMatched);
+    assertEquals(2L, merged.totalMismatched);
+    assertTrue(merged.tablesWithMismatches.contains("t1"));
+    assertEquals(1, merged.tablesWithMismatches.size());
+  }
+
+  @Test
+  public void testExtractOutput_Match() {
+    Instant start = Instant.now();
+    ValidationSummaryCombineFn fn = new ValidationSummaryCombineFn("run1", start, "src", "dst");
+
+    ValidationSummaryAccumulator acc = new ValidationSummaryAccumulator();
+    acc.totalTables = 2;
+    acc.totalMatched = 100;
+    acc.totalMismatched = 0;
+
+    ValidationSummary summary = fn.extractOutput(acc);
+
+    assertEquals("MATCH", summary.getStatus());
+    assertEquals("run1", summary.getRunId());
+    assertEquals("src", summary.getSourceDatabase());
+    assertEquals("dst", summary.getDestinationDatabase());
+    assertEquals(2L, (long) summary.getTotalTablesValidated());
+    assertEquals(100L, (long) summary.getTotalRowsMatched());
+    assertEquals(0L, (long) summary.getTotalRowsMismatched());
+    assertEquals("", summary.getTablesWithMismatches());
+    assertEquals(start, summary.getStartTimestamp());
+  }
+
+  @Test
+  public void testExtractOutput_Mismatch() {
+    ValidationSummaryCombineFn fn =
+        new ValidationSummaryCombineFn("run1", Instant.now(), "src", "dst");
+
+    ValidationSummaryAccumulator acc = new ValidationSummaryAccumulator();
+    acc.totalTables = 1;
+    acc.totalMatched = 50;
+    acc.totalMismatched = 5;
+    acc.tablesWithMismatches.add("t1");
+
+    ValidationSummary summary = fn.extractOutput(acc);
+
+    assertEquals("MISMATCH", summary.getStatus());
+    assertEquals(5L, (long) summary.getTotalRowsMismatched());
+    assertEquals("t1", summary.getTablesWithMismatches());
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperBasicTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperBasicTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.mapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.v2.dto.ComparisonRecord;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
+import com.google.cloud.teleport.v2.spanner.type.Type;
+import com.google.cloud.teleport.v2.spanner.utils.ISpannerMigrationTransformer;
+import com.google.cloud.teleport.v2.spanner.utils.MigrationTransformationResponse;
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * This test tests for coverage of mapping scenarios from {@link GenericRecord} and {@link Struct}.
+ */
+@RunWith(JUnit4.class)
+public class ComparisonRecordMapperBasicTest {
+
+  private ISchemaMapper mockSchemaMapper;
+  private ISpannerMigrationTransformer mockTransformer;
+  private Ddl mockDdl;
+  private ComparisonRecordMapper mapper;
+
+  @Before
+  public void setUp() {
+    mockSchemaMapper = mock(ISchemaMapper.class);
+    mockTransformer = mock(ISpannerMigrationTransformer.class);
+    mockDdl = mock(Ddl.class);
+    mapper = new ComparisonRecordMapper(mockSchemaMapper, mockTransformer, mockDdl);
+  }
+
+  @Test
+  public void testMapFromSpannerStruct() throws Exception {
+    String tableName = "Users";
+    Struct struct =
+        Struct.newBuilder()
+            .set("id")
+            .to(1L)
+            .set("name")
+            .to("Alice")
+            .set("__tableName__")
+            .to(tableName)
+            .build();
+
+    Table mockTable = mock(Table.class);
+    when(mockDdl.table(tableName)).thenReturn(mockTable);
+
+    // Mock primary keys
+    IndexColumn pkCol = IndexColumn.create("id", IndexColumn.Order.ASC);
+    when(mockTable.primaryKeys()).thenReturn(com.google.common.collect.ImmutableList.of(pkCol));
+
+    ComparisonRecord record = mapper.mapFrom(struct);
+
+    assertNotNull(record);
+    assertEquals(tableName, record.getTableName());
+    assertEquals(1, record.getPrimaryKeyColumns().size());
+    assertEquals("id", record.getPrimaryKeyColumns().get(0).getColName());
+    assertEquals("1", record.getPrimaryKeyColumns().get(0).getColValue());
+  }
+
+  @Test
+  public void testMapFromAvroRecord() throws Exception {
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(
+        Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
+
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        Arrays.asList(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+    payload.put("id", 1L);
+    payload.put("name", "Alice");
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "Users");
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    String tableName = "Users";
+    when(mockSchemaMapper.getSpannerTableName(anyString(), anyString())).thenReturn(tableName);
+    when(mockSchemaMapper.getSpannerColumnName(anyString(), anyString(), anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(2)); // Identity column mapping
+
+    when(mockSchemaMapper.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+    when(mockSchemaMapper.getSpannerColumns(anyString(), anyString()))
+        .thenReturn(Arrays.asList("id", "name"));
+    when(mockSchemaMapper.getSourceColumnName(anyString(), anyString(), anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(2));
+    when(mockSchemaMapper.getSpannerColumnType(
+            anyString(), anyString(), org.mockito.ArgumentMatchers.eq("id")))
+        .thenReturn(Type.int64());
+    when(mockSchemaMapper.getSpannerColumnType(
+            anyString(), anyString(), org.mockito.ArgumentMatchers.eq("name")))
+        .thenReturn(Type.string());
+    when(mockSchemaMapper.colExistsAtSource(anyString(), anyString(), anyString()))
+        .thenReturn(true);
+
+    Table mockTable = mock(Table.class);
+    when(mockDdl.table(tableName)).thenReturn(mockTable);
+    IndexColumn pkCol = IndexColumn.create("id", IndexColumn.Order.ASC);
+    when(mockTable.primaryKeys()).thenReturn(com.google.common.collect.ImmutableList.of(pkCol));
+
+    MigrationTransformationResponse mockResponse = mock(MigrationTransformationResponse.class);
+    when(mockResponse.isEventFiltered()).thenReturn(false);
+    when(mockResponse.getResponseRow()).thenReturn(Collections.emptyMap());
+    when(mockTransformer.toSpannerRow(org.mockito.ArgumentMatchers.any())).thenReturn(mockResponse);
+
+    ComparisonRecord record = mapper.mapFrom(avroRecord);
+
+    assertNotNull(record);
+    assertEquals(tableName, record.getTableName());
+    assertNotNull(record.getHash());
+  }
+
+  @Test
+  public void testMapFromAvroRecord_FilteredEvent() throws Exception {
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(Collections.emptyList());
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        Arrays.asList(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "Users");
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    // Mock transformer to filter the event
+    MigrationTransformationResponse mockResponse = mock(MigrationTransformationResponse.class);
+    when(mockResponse.isEventFiltered()).thenReturn(true);
+    when(mockTransformer.toSpannerRow(org.mockito.ArgumentMatchers.any())).thenReturn(mockResponse);
+
+    ComparisonRecord record = mapper.mapFrom(avroRecord);
+    org.junit.Assert.assertNull(record);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testMapFromAvroRecord_TableNotFound() throws Exception {
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(Collections.emptyList());
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        Arrays.asList(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "Users");
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    when(mockSchemaMapper.getSpannerTableName(anyString(), anyString())).thenReturn("Users");
+    when(mockDdl.table("Users")).thenReturn(null); // Table not found
+
+    // Transformer returns valid response but table check fails later
+    MigrationTransformationResponse mockResponse = mock(MigrationTransformationResponse.class);
+    when(mockResponse.isEventFiltered()).thenReturn(false);
+    when(mockResponse.getResponseRow()).thenReturn(Collections.emptyMap());
+    when(mockTransformer.toSpannerRow(org.mockito.ArgumentMatchers.any())).thenReturn(mockResponse);
+
+    mapper.mapFrom(avroRecord);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testMapFromAvroRecord_MappingException() {
+    // Just throw empty mocks to cause NPE/Exception inside mapFrom
+    mapper.mapFrom((GenericRecord) null);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testMapFromSpannerStruct_TableNotFound() {
+    Struct struct = Struct.newBuilder().set("__tableName__").to("UnknownTable").build();
+
+    when(mockDdl.table("UnknownTable")).thenReturn(null);
+    mapper.mapFrom(struct);
+  }
+
+  @Test
+  public void testMapFromAvroRecord_NullShardId() throws Exception {
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(
+        Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
+
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        Arrays.asList(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+    payload.put("id", 1L);
+    payload.put("name", "Alice");
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "Users");
+    avroRecord.put("shardId", null); // Check null shardId
+    avroRecord.put("payload", payload);
+
+    String tableName = "Users";
+    when(mockSchemaMapper.getSpannerTableName(anyString(), anyString())).thenReturn(tableName);
+    when(mockSchemaMapper.getSpannerColumnName(anyString(), anyString(), anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(2));
+    when(mockSchemaMapper.getSpannerColumns(anyString(), anyString()))
+        .thenReturn(Arrays.asList("id", "name"));
+    when(mockSchemaMapper.colExistsAtSource(anyString(), anyString(), anyString()))
+        .thenReturn(true);
+    when(mockSchemaMapper.getSpannerColumnType(
+            anyString(), anyString(), org.mockito.ArgumentMatchers.eq("id")))
+        .thenReturn(Type.int64());
+    when(mockSchemaMapper.getSpannerColumnType(
+            anyString(), anyString(), org.mockito.ArgumentMatchers.eq("name")))
+        .thenReturn(Type.string());
+
+    Table mockTable = mock(Table.class);
+    when(mockDdl.table(tableName)).thenReturn(mockTable);
+    IndexColumn pkCol = IndexColumn.create("id", IndexColumn.Order.ASC);
+    when(mockTable.primaryKeys()).thenReturn(com.google.common.collect.ImmutableList.of(pkCol));
+
+    when(mockSchemaMapper.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+    when(mockSchemaMapper.getSourceColumnName(anyString(), anyString(), anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(2));
+
+    MigrationTransformationResponse mockResponse = mock(MigrationTransformationResponse.class);
+    when(mockResponse.isEventFiltered()).thenReturn(false);
+    when(mockResponse.getResponseRow()).thenReturn(Collections.emptyMap());
+    when(mockTransformer.toSpannerRow(org.mockito.ArgumentMatchers.any())).thenReturn(mockResponse);
+
+    ComparisonRecord record = mapper.mapFrom(avroRecord);
+    assertNotNull(record);
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperBasicTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperBasicTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.v2.constants.GCSSpannerDVConstants;
 import com.google.cloud.teleport.v2.dto.ComparisonRecord;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
@@ -69,7 +70,7 @@ public class ComparisonRecordMapperBasicTest {
             .to(1L)
             .set("name")
             .to("Alice")
-            .set("__tableName__")
+            .set(GCSSpannerDVConstants.TABLE_NAME_COLUMN)
             .to(tableName)
             .build();
 
@@ -214,7 +215,8 @@ public class ComparisonRecordMapperBasicTest {
 
   @Test(expected = RuntimeException.class)
   public void testMapFromSpannerStruct_TableNotFound() {
-    Struct struct = Struct.newBuilder().set("__tableName__").to("UnknownTable").build();
+    Struct struct =
+        Struct.newBuilder().set(GCSSpannerDVConstants.TABLE_NAME_COLUMN).to("UnknownTable").build();
 
     when(mockDdl.table("UnknownTable")).thenReturn(null);
     mapper.mapFrom(struct);

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperFileOverridesTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperFileOverridesTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Value;
+import com.google.cloud.teleport.v2.constants.GCSSpannerDVConstants;
 import com.google.cloud.teleport.v2.dto.ComparisonRecord;
 import com.google.cloud.teleport.v2.spanner.ddl.Column;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
@@ -159,7 +160,7 @@ public class ComparisonRecordMapperFileOverridesTest {
             .to(100L)
             .set("name")
             .to("Bob")
-            .set("__tableName__")
+            .set(GCSSpannerDVConstants.TABLE_NAME_COLUMN)
             .to("SpannerUsers")
             .build();
 

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperFileOverridesTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperFileOverridesTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.mapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Value;
+import com.google.cloud.teleport.v2.dto.ComparisonRecord;
+import com.google.cloud.teleport.v2.spanner.ddl.Column;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SchemaFileOverridesBasedMapper;
+import com.google.cloud.teleport.v2.spanner.type.Type;
+import com.google.cloud.teleport.v2.spanner.utils.ISpannerMigrationTransformer;
+import com.google.cloud.teleport.v2.spanner.utils.MigrationTransformationResponse;
+import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * This test tests for equivalence between {@link GenericRecord} and {@link Struct} when a file
+ * based schema mapper is used.
+ */
+@RunWith(JUnit4.class)
+public class ComparisonRecordMapperFileOverridesTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private ISpannerMigrationTransformer mockTransformer;
+  private Ddl mockDdl;
+  private File overridesFile;
+  private SchemaFileOverridesBasedMapper schemaMapper;
+  private ComparisonRecordMapper mapper;
+
+  @Before
+  public void setUp() throws Exception {
+    mockTransformer = mock(ISpannerMigrationTransformer.class);
+    mockDdl = mock(Ddl.class);
+
+    // Create a temporary overrides file
+    overridesFile = temporaryFolder.newFile("overrides.json");
+    String overridesJson =
+        "{\n"
+            + "  \"renamedTables\": {\n"
+            + "    \"SourceUsers\": \"SpannerUsers\"\n"
+            + "  },\n"
+            + "  \"renamedColumns\": {\n"
+            + "    \"SourceUsers\": {\n"
+            + "      \"user_name\": \"name\"\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+    Files.write(overridesFile.toPath(), overridesJson.getBytes(StandardCharsets.UTF_8));
+
+    // Mock DDL
+    when(mockDdl.dialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+    Table t1 = mock(Table.class);
+    when(mockDdl.table("SpannerUsers")).thenReturn(t1);
+    when(t1.primaryKeys())
+        .thenReturn(ImmutableList.of(IndexColumn.create("id", IndexColumn.Order.ASC)));
+
+    // Mock columns for SpannerUsers
+    Column idCol = mock(Column.class);
+    when(t1.column("id")).thenReturn(idCol);
+    when(idCol.type()).thenReturn(Type.int64());
+    when(idCol.name()).thenReturn("id");
+
+    Column nameCol = mock(Column.class);
+    // Spanner column name is 'name' (mapped from 'user_name')
+    when(t1.column("name")).thenReturn(nameCol);
+    when(nameCol.type()).thenReturn(Type.string());
+    when(nameCol.name()).thenReturn("name");
+
+    when(t1.columns()).thenReturn(ImmutableList.of(idCol, nameCol));
+
+    // Initialize mapper
+    schemaMapper = new SchemaFileOverridesBasedMapper(overridesFile.getAbsolutePath(), mockDdl);
+    mapper = new ComparisonRecordMapper(schemaMapper, mockTransformer, mockDdl);
+  }
+
+  @Test
+  public void testMapFromAvroRecord_RenamedTableAndColumn() throws Exception {
+    // Payload Schema
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user_name", Schema.create(Schema.Type.STRING), null, null)));
+
+    // Avro Schema
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+    payload.put("id", 100L);
+    payload.put("user_name", "Bob");
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "SourceUsers");
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    // Mock Transformer Behavior
+    MigrationTransformationResponse mockResponse = mock(MigrationTransformationResponse.class);
+    when(mockResponse.isEventFiltered()).thenReturn(false);
+    // Transformer returns Spanner column names and values
+    when(mockResponse.getResponseRow())
+        .thenReturn(Map.of("id", Value.int64(100L), "name", Value.string("Bob")));
+    when(mockTransformer.toSpannerRow(org.mockito.ArgumentMatchers.any())).thenReturn(mockResponse);
+
+    ComparisonRecord record = mapper.mapFrom(avroRecord);
+
+    assertNotNull(record);
+    assertEquals("SpannerUsers", record.getTableName());
+    assertEquals(1, record.getPrimaryKeyColumns().size());
+    // Verify hash is generated
+    assertNotNull(record.getHash());
+  }
+
+  @Test
+  public void testMapFromSpannerStruct_MatchesAvro() throws Exception {
+    Struct spannerStruct =
+        Struct.newBuilder()
+            .set("id")
+            .to(100L)
+            .set("name")
+            .to("Bob")
+            .set("__tableName__")
+            .to("SpannerUsers")
+            .build();
+
+    ComparisonRecord spannerRecord = mapper.mapFrom(spannerStruct);
+
+    // Re-create Avro record
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user_name", Schema.create(Schema.Type.STRING), null, null)));
+
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+    payload.put("id", 100L);
+    payload.put("user_name", "Bob");
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "SourceUsers");
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    MigrationTransformationResponse mockResponse = mock(MigrationTransformationResponse.class);
+    when(mockResponse.isEventFiltered()).thenReturn(false);
+    when(mockResponse.getResponseRow())
+        .thenReturn(Map.of("id", Value.int64(100L), "name", Value.string("Bob")));
+    when(mockTransformer.toSpannerRow(org.mockito.ArgumentMatchers.any())).thenReturn(mockResponse);
+
+    ComparisonRecord avroComparisonRecord = mapper.mapFrom(avroRecord);
+
+    assertEquals(spannerRecord.getHash(), avroComparisonRecord.getHash());
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperIdentityTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperIdentityTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.v2.constants.GCSSpannerDVConstants;
 import com.google.cloud.teleport.v2.dto.ComparisonRecord;
 import com.google.cloud.teleport.v2.spanner.ddl.Column;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
@@ -111,7 +112,7 @@ public class ComparisonRecordMapperIdentityTest {
             .to(1L)
             .set("name")
             .to("Alice")
-            .set("__tableName__")
+            .set(GCSSpannerDVConstants.TABLE_NAME_COLUMN)
             .to(tableName)
             .build();
 
@@ -133,7 +134,7 @@ public class ComparisonRecordMapperIdentityTest {
             .to(1L)
             .set("name")
             .to((String) null)
-            .set("__tableName__")
+            .set(GCSSpannerDVConstants.TABLE_NAME_COLUMN)
             .to(tableName)
             .build();
 
@@ -178,7 +179,7 @@ public class ComparisonRecordMapperIdentityTest {
             .to(1L)
             .set("name")
             .to("Alice")
-            .set("__tableName__")
+            .set(GCSSpannerDVConstants.TABLE_NAME_COLUMN)
             .to(tableName)
             .build();
 

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperIdentityTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperIdentityTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.mapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.v2.dto.ComparisonRecord;
+import com.google.cloud.teleport.v2.spanner.ddl.Column;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.IdentityMapper;
+import com.google.cloud.teleport.v2.spanner.type.Type;
+import com.google.cloud.teleport.v2.spanner.utils.ISpannerMigrationTransformer;
+import com.google.cloud.teleport.v2.spanner.utils.MigrationTransformationResponse;
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ComparisonRecordMapperIdentityTest {
+
+  private IdentityMapper identityMapper;
+  private ISpannerMigrationTransformer mockTransformer;
+  private Ddl mockDdl;
+  private ComparisonRecordMapper mapper;
+
+  @Before
+  public void setUp() {
+    mockDdl = mock(Ddl.class);
+    when(mockDdl.dialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+    identityMapper = new IdentityMapper(mockDdl);
+    mockTransformer = mock(ISpannerMigrationTransformer.class);
+    mapper = new ComparisonRecordMapper(identityMapper, mockTransformer, mockDdl);
+  }
+
+  @Test
+  public void testMapFromAvroRecord_Identity() throws Exception {
+    String tableName = "Users";
+    setupDdl(tableName, Arrays.asList("id", "name"), Arrays.asList(Type.int64(), Type.string()));
+
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(
+        Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
+
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        Arrays.asList(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+    payload.put("id", 1L);
+    payload.put("name", "Alice");
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", tableName);
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    MigrationTransformationResponse mockResponse = mock(MigrationTransformationResponse.class);
+    when(mockResponse.isEventFiltered()).thenReturn(false);
+    when(mockResponse.getResponseRow()).thenReturn(Collections.emptyMap());
+    when(mockTransformer.toSpannerRow(any())).thenReturn(mockResponse);
+
+    ComparisonRecord record = mapper.mapFrom(avroRecord);
+
+    assertNotNull(record);
+    assertEquals(tableName, record.getTableName());
+    assertNotNull(record.getHash());
+  }
+
+  @Test
+  public void testMapFromSpannerStruct_Identity() throws Exception {
+    String tableName = "Users";
+    setupDdl(tableName, Arrays.asList("id", "name"), Arrays.asList(Type.int64(), Type.string()));
+
+    Struct struct =
+        Struct.newBuilder()
+            .set("id")
+            .to(1L)
+            .set("name")
+            .to("Alice")
+            .set("__tableName__")
+            .to(tableName)
+            .build();
+
+    ComparisonRecord record = mapper.mapFrom(struct);
+
+    assertNotNull(record);
+    assertEquals(tableName, record.getTableName());
+    assertNotNull(record.getHash());
+  }
+
+  @Test
+  public void testMapWithNullValues() throws Exception {
+    String tableName = "Users";
+    setupDdl(tableName, Arrays.asList("id", "name"), Arrays.asList(Type.int64(), Type.string()));
+
+    Struct struct =
+        Struct.newBuilder()
+            .set("id")
+            .to(1L)
+            .set("name")
+            .to((String) null)
+            .set("__tableName__")
+            .to(tableName)
+            .build();
+
+    ComparisonRecord record = mapper.mapFrom(struct);
+
+    assertNotNull(record);
+    assertEquals(tableName, record.getTableName());
+  }
+
+  @Test
+  public void testMapFromSpannerStruct_MatchesAvro() throws Exception {
+    String tableName = "Users";
+    setupDdl(tableName, Arrays.asList("id", "name"), Arrays.asList(Type.int64(), Type.string()));
+
+    // 1. Create Avro Record
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(
+        Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
+
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        Arrays.asList(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+    payload.put("id", 1L);
+    payload.put("name", "Alice");
+
+    GenericRecord avroGenericRecord = new GenericData.Record(avroSchema);
+    avroGenericRecord.put("tableName", tableName);
+    avroGenericRecord.put("shardId", "shard1");
+    avroGenericRecord.put("payload", payload);
+
+    // 2. Create Spanner Struct
+    Struct spannerStruct =
+        Struct.newBuilder()
+            .set("id")
+            .to(1L)
+            .set("name")
+            .to("Alice")
+            .set("__tableName__")
+            .to(tableName)
+            .build();
+
+    // 3. Mock Transformer (Required for Avro path)
+    MigrationTransformationResponse mockResponse = mock(MigrationTransformationResponse.class);
+    when(mockResponse.isEventFiltered()).thenReturn(false);
+    when(mockResponse.getResponseRow()).thenReturn(Collections.emptyMap());
+    when(mockTransformer.toSpannerRow(any())).thenReturn(mockResponse);
+
+    // 4. Map both
+    ComparisonRecord avroRec = mapper.mapFrom(avroGenericRecord);
+    ComparisonRecord spannerRec = mapper.mapFrom(spannerStruct);
+
+    // 5. Assertions
+    assertNotNull(avroRec);
+    assertNotNull(spannerRec);
+    assertEquals(tableName, avroRec.getTableName());
+    assertEquals(tableName, spannerRec.getTableName());
+    assertEquals(
+        "Hashes should match for equivalent data", avroRec.getHash(), spannerRec.getHash());
+  }
+
+  private void setupDdl(String tableName, List<String> columns, List<Type> types) {
+    Table mockTable = mock(Table.class);
+    when(mockDdl.table(tableName)).thenReturn(mockTable);
+
+    // Setup primary key (assume first column is PK)
+    IndexColumn pkCol = IndexColumn.create(columns.get(0), IndexColumn.Order.ASC);
+    when(mockTable.primaryKeys()).thenReturn(ImmutableList.of(pkCol));
+
+    // Setup columns
+    ImmutableList.Builder<Column> colBuilder = ImmutableList.builder();
+    for (int i = 0; i < columns.size(); i++) {
+      Column col = mock(Column.class);
+      when(col.name()).thenReturn(columns.get(i));
+      when(col.type()).thenReturn(types.get(i));
+      when(mockTable.column(columns.get(i))).thenReturn(col);
+      colBuilder.add(col);
+    }
+    when(mockTable.columns()).thenReturn(colBuilder.build());
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperSessionTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperSessionTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.mapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Value;
+import com.google.cloud.teleport.v2.dto.ComparisonRecord;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SessionBasedMapper;
+import com.google.cloud.teleport.v2.spanner.utils.ISpannerMigrationTransformer;
+import com.google.cloud.teleport.v2.spanner.utils.MigrationTransformationResponse;
+import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * This test tests for equivalence between {@link GenericRecord} and {@link Struct} when a session
+ * file based schema mapper is used.
+ */
+@RunWith(JUnit4.class)
+public class ComparisonRecordMapperSessionTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private ISpannerMigrationTransformer mockTransformer;
+  private Ddl mockDdl;
+  private File sessionFile;
+  private SessionBasedMapper schemaMapper;
+  private ComparisonRecordMapper mapper;
+
+  @Before
+  public void setUp() throws Exception {
+    mockTransformer = mock(ISpannerMigrationTransformer.class);
+    mockDdl = mock(Ddl.class);
+
+    // Create a temporary session file
+    sessionFile = temporaryFolder.newFile("session.json");
+    String sessionJson =
+        "{\n"
+            + "  \"SpSchema\": {\n"
+            + "    \"t1\": {\n"
+            + "      \"Name\": \"SpannerUsers\",\n"
+            + "      \"ColIds\": [\"c1\", \"c2\"],\n"
+            + "      \"ColDefs\": {\n"
+            + "        \"c1\": {\"Name\": \"id\", \"Type\": {\"Name\": \"INT64\"}},\n"
+            + "        \"c2\": {\"Name\": \"full_name\", \"Type\": {\"Name\": \"STRING\"}}\n"
+            + "      },\n"
+            + "      \"PrimaryKeys\": [{\"ColId\": \"c1\", \"Order\": 1}]\n"
+            + "    }\n"
+            + "  },\n"
+            + "  \"SrcSchema\": {\n"
+            + "    \"t1\": {\n"
+            + "      \"Name\": \"SourceUsers\",\n"
+            + "      \"ColIds\": [\"c1\", \"c2\"],\n"
+            + "      \"ColDefs\": {\n"
+            + "        \"c1\": {\"Name\": \"user_id\", \"Type\": {\"Name\": \"LONG\"}},\n"
+            + "        \"c2\": {\"Name\": \"name\", \"Type\": {\"Name\": \"STRING\"}}\n"
+            + "      }\n"
+            + "    }\n"
+            + "  },\n"
+            + "  \"SyntheticPKeys\": {}\n"
+            + "}";
+    Files.write(sessionFile.toPath(), sessionJson.getBytes(StandardCharsets.UTF_8));
+
+    // Mock DDL to match Spanner schema in session file
+    when(mockDdl.dialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+    Table t1 = mock(Table.class);
+    when(mockDdl.table("SpannerUsers")).thenReturn(t1);
+    when(t1.primaryKeys())
+        .thenReturn(ImmutableList.of(IndexColumn.create("id", IndexColumn.Order.ASC)));
+    com.google.cloud.teleport.v2.spanner.ddl.Column idCol =
+        mock(com.google.cloud.teleport.v2.spanner.ddl.Column.class);
+    when(t1.column("id")).thenReturn(idCol);
+    when(idCol.type()).thenReturn(com.google.cloud.teleport.v2.spanner.type.Type.int64());
+    com.google.cloud.teleport.v2.spanner.ddl.Column nameCol =
+        mock(com.google.cloud.teleport.v2.spanner.ddl.Column.class);
+    when(t1.column("full_name")).thenReturn(nameCol);
+    when(nameCol.type()).thenReturn(com.google.cloud.teleport.v2.spanner.type.Type.string());
+
+    // Initialize mapper
+    schemaMapper = new SessionBasedMapper(sessionFile.getAbsolutePath(), mockDdl);
+    mapper = new ComparisonRecordMapper(schemaMapper, mockTransformer, mockDdl);
+  }
+
+  @Test
+  public void testMapFromAvroRecord_RenamedTableAndColumn() throws Exception {
+    // Schema for Payload (Source Schema)
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("user_id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
+
+    // Schema for SourceRow (Avro wrapper)
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+    payload.put("user_id", 100L);
+    payload.put("name", "Alice");
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "SourceUsers");
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    // Mock Transformer
+    MigrationTransformationResponse mockResponse = mock(MigrationTransformationResponse.class);
+    when(mockResponse.isEventFiltered()).thenReturn(false);
+    when(mockResponse.getResponseRow())
+        .thenReturn(Map.of("id", Value.int64(100L), "full_name", Value.string("Alice")));
+    when(mockTransformer.toSpannerRow(org.mockito.ArgumentMatchers.any())).thenReturn(mockResponse);
+
+    ComparisonRecord record = mapper.mapFrom(avroRecord);
+
+    assertNotNull(record);
+    assertEquals("SpannerUsers", record.getTableName());
+    assertEquals(1, record.getPrimaryKeyColumns().size());
+    assertEquals("id", record.getPrimaryKeyColumns().get(0).getColName());
+    assertEquals("100", record.getPrimaryKeyColumns().get(0).getColValue());
+    assertNotNull(record.getHash());
+  }
+
+  @Test
+  public void testMapFromSpannerStruct_MatchesAvro() throws Exception {
+    // Spanner Struct representing the same data
+    Struct spannerStruct =
+        Struct.newBuilder()
+            .set("id")
+            .to(100L)
+            .set("full_name")
+            .to("Alice")
+            .set("__tableName__")
+            .to("SpannerUsers")
+            .build();
+
+    // Map Spanner Struct
+    ComparisonRecord spannerRecord = mapper.mapFrom(spannerStruct);
+
+    // Re-create Avro record from previous test for verification
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("user_id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
+
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+    payload.put("user_id", 100L);
+    payload.put("name", "Alice");
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "SourceUsers");
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    MigrationTransformationResponse mockResponse = mock(MigrationTransformationResponse.class);
+    when(mockResponse.isEventFiltered()).thenReturn(false);
+    when(mockResponse.getResponseRow())
+        .thenReturn(Map.of("id", Value.int64(100L), "full_name", Value.string("Alice")));
+    when(mockTransformer.toSpannerRow(org.mockito.ArgumentMatchers.any())).thenReturn(mockResponse);
+
+    ComparisonRecord avroComparisonRecord = mapper.mapFrom(avroRecord);
+
+    assertEquals(spannerRecord.getHash(), avroComparisonRecord.getHash());
+    assertEquals(spannerRecord.getTableName(), avroComparisonRecord.getTableName());
+  }
+
+  @Test
+  public void testMapWithNullValues() throws Exception {
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    // Nullable Name
+    Schema nullableString =
+        Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING));
+    payloadSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("user_id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", nullableString, null, null)));
+
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+    payload.put("user_id", 200L);
+    payload.put("name", null);
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "SourceUsers");
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    when(mockTransformer.toSpannerRow(org.mockito.ArgumentMatchers.any()))
+        .thenAnswer(
+            invocation -> {
+              return new MigrationTransformationResponse(
+                  Map.of("id", Value.int64(200L), "full_name", Value.string(null)), false);
+            });
+
+    ComparisonRecord record = mapper.mapFrom(avroRecord);
+    assertNotNull(record);
+    assertEquals("SpannerUsers", record.getTableName());
+  }
+
+  @Test
+  public void testMapWithTypeConversions() throws Exception {
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("user_id", Schema.create(Schema.Type.INT), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
+
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+    payload.put("user_id", 300);
+    payload.put("name", "Charlie");
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "SourceUsers");
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    when(mockTransformer.toSpannerRow(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(
+            new MigrationTransformationResponse(
+                Map.of("id", Value.int64(300L), "full_name", Value.string("Charlie")), false));
+
+    ComparisonRecord record = mapper.mapFrom(avroRecord);
+    assertNotNull(record);
+    assertEquals("SpannerUsers", record.getTableName());
+    assertEquals("300", record.getPrimaryKeyColumns().get(0).getColValue());
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperSessionTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperSessionTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Value;
+import com.google.cloud.teleport.v2.constants.GCSSpannerDVConstants;
 import com.google.cloud.teleport.v2.dto.ComparisonRecord;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
@@ -166,7 +167,7 @@ public class ComparisonRecordMapperSessionTest {
             .to(100L)
             .set("full_name")
             .to("Alice")
-            .set("__tableName__")
+            .set(GCSSpannerDVConstants.TABLE_NAME_COLUMN)
             .to("SpannerUsers")
             .build();
 

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperStringOverridesTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperStringOverridesTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Value;
+import com.google.cloud.teleport.v2.constants.GCSSpannerDVConstants;
 import com.google.cloud.teleport.v2.dto.ComparisonRecord;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
@@ -143,7 +144,7 @@ public class ComparisonRecordMapperStringOverridesTest {
             .to(100L)
             .set("name")
             .to("Bob")
-            .set("__tableName__")
+            .set(GCSSpannerDVConstants.TABLE_NAME_COLUMN)
             .to("SpannerUsers")
             .build();
 

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperStringOverridesTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperStringOverridesTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.mapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Value;
+import com.google.cloud.teleport.v2.dto.ComparisonRecord;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SchemaStringOverridesBasedMapper;
+import com.google.cloud.teleport.v2.spanner.utils.ISpannerMigrationTransformer;
+import com.google.cloud.teleport.v2.spanner.utils.MigrationTransformationResponse;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * This test tests for equivalence between {@link GenericRecord} and {@link Struct} when a String
+ * based schema mapper is used.
+ */
+@RunWith(JUnit4.class)
+public class ComparisonRecordMapperStringOverridesTest {
+
+  private ISpannerMigrationTransformer mockTransformer;
+  private Ddl mockDdl;
+  private SchemaStringOverridesBasedMapper schemaMapper;
+  private ComparisonRecordMapper mapper;
+
+  @Before
+  public void setUp() throws Exception {
+    mockTransformer = mock(ISpannerMigrationTransformer.class);
+    mockDdl = mock(Ddl.class);
+
+    // Define overrides
+    // Table: SourceUsers -> SpannerUsers
+    // Column: SourceUsers.user_name -> SourceUsers.name (mapped to name in Spanner)
+    Map<String, String> overridesMap =
+        ImmutableMap.of(
+            "tableOverrides", "[{SourceUsers, SpannerUsers}]",
+            "columnOverrides", "[{SourceUsers.user_name, SourceUsers.name}]");
+
+    // Mock DDL
+    when(mockDdl.dialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+    Table t1 = mock(Table.class);
+    when(mockDdl.table("SpannerUsers")).thenReturn(t1);
+    when(t1.primaryKeys())
+        .thenReturn(ImmutableList.of(IndexColumn.create("id", IndexColumn.Order.ASC)));
+
+    // Mock columns
+    com.google.cloud.teleport.v2.spanner.ddl.Column idCol =
+        mock(com.google.cloud.teleport.v2.spanner.ddl.Column.class);
+    when(t1.column("id")).thenReturn(idCol);
+    when(idCol.type()).thenReturn(com.google.cloud.teleport.v2.spanner.type.Type.int64());
+    when(idCol.name()).thenReturn("id");
+
+    com.google.cloud.teleport.v2.spanner.ddl.Column nameCol =
+        mock(com.google.cloud.teleport.v2.spanner.ddl.Column.class);
+    when(t1.column("name")).thenReturn(nameCol);
+    when(nameCol.type()).thenReturn(com.google.cloud.teleport.v2.spanner.type.Type.string());
+    when(nameCol.name()).thenReturn("name");
+
+    when(t1.columns()).thenReturn(ImmutableList.of(idCol, nameCol));
+
+    // Initialize mapper
+    schemaMapper = new SchemaStringOverridesBasedMapper(overridesMap, mockDdl);
+    mapper = new ComparisonRecordMapper(schemaMapper, mockTransformer, mockDdl);
+  }
+
+  @Test
+  public void testMapFromAvroRecord_RenamedTableAndColumn() throws Exception {
+    // Payload Schema
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user_name", Schema.create(Schema.Type.STRING), null, null)));
+
+    // Avro Schema
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+    payload.put("id", 100L);
+    payload.put("user_name", "Bob");
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "SourceUsers");
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    // Mock Transformer Behavior
+    MigrationTransformationResponse mockResponse = mock(MigrationTransformationResponse.class);
+    when(mockResponse.isEventFiltered()).thenReturn(false);
+    when(mockResponse.getResponseRow())
+        .thenReturn(Map.of("id", Value.int64(100L), "name", Value.string("Bob")));
+    when(mockTransformer.toSpannerRow(org.mockito.ArgumentMatchers.any())).thenReturn(mockResponse);
+
+    ComparisonRecord record = mapper.mapFrom(avroRecord);
+
+    assertNotNull(record);
+    assertEquals("SpannerUsers", record.getTableName());
+    assertEquals(1, record.getPrimaryKeyColumns().size());
+    // Verify hash
+    assertNotNull(record.getHash());
+  }
+
+  @Test
+  public void testMapFromSpannerStruct_MatchesAvro() throws Exception {
+    Struct spannerStruct =
+        Struct.newBuilder()
+            .set("id")
+            .to(100L)
+            .set("name")
+            .to("Bob")
+            .set("__tableName__")
+            .to("SpannerUsers")
+            .build();
+
+    ComparisonRecord spannerRecord = mapper.mapFrom(spannerStruct);
+
+    // Re-create Avro record
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("user_name", Schema.create(Schema.Type.STRING), null, null)));
+
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        ImmutableList.of(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+    payload.put("id", 100L);
+    payload.put("user_name", "Bob");
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "SourceUsers");
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    MigrationTransformationResponse mockResponse = mock(MigrationTransformationResponse.class);
+    when(mockResponse.isEventFiltered()).thenReturn(false);
+    when(mockResponse.getResponseRow())
+        .thenReturn(Map.of("id", Value.int64(100L), "name", Value.string("Bob")));
+    when(mockTransformer.toSpannerRow(org.mockito.ArgumentMatchers.any())).thenReturn(mockResponse);
+
+    ComparisonRecord avroComparisonRecord = mapper.mapFrom(avroRecord);
+
+    assertEquals(spannerRecord.getHash(), avroComparisonRecord.getHash());
+  }
+}


### PR DESCRIPTION
### TL;DR

Added core functions for data validation in the GCS-to-Spanner data validation pipeline.

### What changed?

Added several key components for the GCS-to-Spanner data validation pipeline:

1. `IdentityGenericRecordFn`: A simple function that returns GenericRecords as-is, allowing AvroIO to parse records while deferring coder inference.

2. `SchemaMapperProviderFn`: Provides the appropriate schema mapper implementation based on configuration parameters (session file, schema overrides file, or string overrides).

3. `ValidationSummaryCombineFn`: Aggregates individual table validation statistics into a global validation summary, tracking matches, mismatches, and affected tables.

4. `ComparisonRecordMapper`: Maps data from different sources (Avro GenericRecords or Spanner Structs) into a unified ComparisonRecord format for validation, handling schema mapping and hash generation.

### How to test?

The implementation includes comprehensive unit tests for each component:

- `IdentityGenericRecordFnTest`: Verifies the identity function works correctly
- `SchemaMapperProviderFnTest`: Tests different schema mapper selection scenarios
- `ValidationSummaryCombineFnTest`: Tests accumulation and merging of validation statistics
- `ComparisonRecordMapper*Test` (multiple variants): Tests mapping from different sources with various schema mapping configurations