### PR TITLE
feat(dv): hashing and schema processing

### DIFF
--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dofn/ProcessInformationSchemaFn.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dofn/ProcessInformationSchemaFn.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dofn;
+
+import com.google.cloud.spanner.BatchClient;
+import com.google.cloud.spanner.BatchReadOnlyTransaction;
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.TimestampBound;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.InformationSchemaScanner;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
+import org.apache.beam.sdk.transforms.DoFn;
+
+public class ProcessInformationSchemaFn extends DoFn<Void, Ddl> {
+
+  private final SpannerConfig spannerConfig;
+
+  private transient SpannerAccessor spannerAccessor;
+  private transient Dialect dialect;
+
+  public ProcessInformationSchemaFn(SpannerConfig spannerConfig) {
+    this.spannerConfig = spannerConfig;
+  }
+
+  @Setup
+  public void setup() throws Exception {
+    spannerAccessor = SpannerAccessor.getOrCreate(spannerConfig);
+
+    DatabaseAdminClient databaseAdminClient = spannerAccessor.getDatabaseAdminClient();
+    dialect =
+        databaseAdminClient
+            .getDatabase(spannerConfig.getInstanceId().get(), spannerConfig.getDatabaseId().get())
+            .getDialect();
+  }
+
+  @Teardown
+  public void teardown() throws Exception {
+    if (spannerAccessor != null) {
+      spannerAccessor.close();
+    }
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c) {
+    Ddl mainDdl = getInformationSchemaAsDdl(spannerAccessor, dialect);
+    c.output(mainDdl);
+  }
+
+  private Ddl getInformationSchemaAsDdl(SpannerAccessor accessor, Dialect dialect) {
+    BatchClient batchClient = accessor.getBatchClient();
+    BatchReadOnlyTransaction context =
+        batchClient.batchReadOnlyTransaction(TimestampBound.strong());
+    InformationSchemaScanner scanner = new InformationSchemaScanner(context, dialect);
+    return scanner.scan();
+  }
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dofn/SourceHashFn.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dofn/SourceHashFn.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dofn;
+
+import com.google.cloud.teleport.v2.dto.ComparisonRecord;
+import com.google.cloud.teleport.v2.mapper.ComparisonRecordMapper;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
+import java.util.Objects;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.PCollectionView;
+
+/** A {@link DoFn} that converts {@link GenericRecord} to {@link ComparisonRecord}. */
+public class SourceHashFn extends DoFn<GenericRecord, ComparisonRecord> {
+
+  private final PCollectionView<Ddl> ddlView;
+  private final SerializableFunction<Ddl, ISchemaMapper> schemaMapperProvider;
+
+  private transient ComparisonRecordMapper comparisonRecordMapper;
+
+  public SourceHashFn(
+      PCollectionView<Ddl> ddlView, SerializableFunction<Ddl, ISchemaMapper> schemaMapperProvider) {
+    this.ddlView = ddlView;
+    this.schemaMapperProvider = schemaMapperProvider;
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c) {
+    Ddl ddl = c.sideInput(ddlView);
+
+    // lazy initialization of the mapper.
+    if (comparisonRecordMapper == null) {
+      comparisonRecordMapper =
+          new ComparisonRecordMapper(schemaMapperProvider.apply(ddl), null, ddl);
+    }
+
+    ComparisonRecord comparisonRecord =
+        comparisonRecordMapper.mapFrom(Objects.requireNonNull(c.element()));
+    if (comparisonRecord != null) {
+      c.output(comparisonRecord);
+    }
+  }
+}

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dofn/SpannerHashFn.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dofn/SpannerHashFn.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dofn;
+
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.v2.dto.ComparisonRecord;
+import com.google.cloud.teleport.v2.mapper.ComparisonRecordMapper;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
+import java.util.Objects;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.PCollectionView;
+
+public class SpannerHashFn extends DoFn<Struct, ComparisonRecord> {
+
+  private final PCollectionView<Ddl> ddlView;
+  private final SerializableFunction<Ddl, ISchemaMapper> schemaMapperProvider;
+
+  private transient ComparisonRecordMapper comparisonRecordMapper;
+
+  public SpannerHashFn(
+      PCollectionView<Ddl> ddlView, SerializableFunction<Ddl, ISchemaMapper> schemaMapperProvider) {
+    this.ddlView = ddlView;
+    this.schemaMapperProvider = schemaMapperProvider;
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c) {
+    Ddl ddl = c.sideInput(ddlView);
+    // lazy initialization of the mapper.
+    if (comparisonRecordMapper == null) {
+      comparisonRecordMapper =
+          new ComparisonRecordMapper(schemaMapperProvider.apply(ddl), null, ddl);
+    }
+
+    ComparisonRecord comparisonRecord =
+        comparisonRecordMapper.mapFrom(Objects.requireNonNull(c.element()));
+    if (comparisonRecord != null) {
+      c.output(comparisonRecord);
+    }
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/dofn/ProcessInformationSchemaFnTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/dofn/ProcessInformationSchemaFnTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dofn;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.BatchClient;
+import com.google.cloud.spanner.BatchReadOnlyTransaction;
+import com.google.cloud.spanner.Database;
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.TimestampBound;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.InformationSchemaScanner;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+/** Unit tests for {@link ProcessInformationSchemaFn}. */
+@RunWith(JUnit4.class)
+public class ProcessInformationSchemaFnTest {
+
+  @Mock private SpannerConfig spannerConfig;
+  @Mock private SpannerAccessor spannerAccessor;
+  @Mock private DatabaseAdminClient databaseAdminClient;
+  @Mock private Database database;
+  @Mock private BatchClient batchClient;
+  @Mock private BatchReadOnlyTransaction batchReadOnlyTransaction;
+  @Mock private DoFn<Void, Ddl>.ProcessContext processContext;
+  @Mock private Ddl ddl;
+
+  private MockedStatic<SpannerAccessor> mockedSpannerAccessor;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    mockedSpannerAccessor = mockStatic(SpannerAccessor.class);
+    mockedSpannerAccessor
+        .when(() -> SpannerAccessor.getOrCreate(spannerConfig))
+        .thenReturn(spannerAccessor);
+
+    when(spannerConfig.getInstanceId()).thenReturn(StaticValueProvider.of("instance"));
+    when(spannerConfig.getDatabaseId()).thenReturn(StaticValueProvider.of("database"));
+
+    when(spannerAccessor.getDatabaseAdminClient()).thenReturn(databaseAdminClient);
+
+    when(databaseAdminClient.getDatabase("instance", "database")).thenReturn(database);
+
+    when(database.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+
+    when(spannerAccessor.getBatchClient()).thenReturn(batchClient);
+    when(batchClient.batchReadOnlyTransaction(any(TimestampBound.class)))
+        .thenReturn(batchReadOnlyTransaction);
+  }
+
+  @After
+  public void tearDown() {
+    mockedSpannerAccessor.close();
+  }
+
+  @Test
+  public void testProcessElement() throws Exception {
+    ProcessInformationSchemaFn fn = new ProcessInformationSchemaFn(spannerConfig);
+
+    fn.setup();
+
+    try (MockedConstruction<InformationSchemaScanner> mockedScanner =
+        mockConstruction(
+            InformationSchemaScanner.class,
+            (mock, context) -> {
+              when(mock.scan()).thenReturn(ddl);
+            })) {
+
+      fn.processElement(processContext);
+
+      verify(processContext).output(ddl);
+
+      assert (mockedScanner.constructed().size() == 1);
+      verify(mockedScanner.constructed().get(0)).scan();
+    }
+
+    fn.teardown();
+    verify(spannerAccessor).close();
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/dofn/SourceHashFnTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/dofn/SourceHashFnTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dofn;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.dto.ComparisonRecord;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
+import com.google.common.collect.ImmutableList;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+
+@RunWith(JUnit4.class)
+public class SourceHashFnTest {
+
+  @Test
+  public void testProcessElement() {
+    // Mock dependencies
+    PCollectionView<Ddl> ddlView = mock(PCollectionView.class);
+    SerializableFunction<Ddl, ISchemaMapper> schemaMapperProvider =
+        mock(SerializableFunction.class);
+    ISchemaMapper schemaMapper = mock(ISchemaMapper.class);
+    Ddl ddl = mock(Ddl.class);
+    DoFn<GenericRecord, ComparisonRecord>.ProcessContext context = mock(DoFn.ProcessContext.class);
+
+    // Prepare behavior
+    when(context.sideInput(ddlView)).thenReturn(ddl);
+    when(schemaMapperProvider.apply(ddl)).thenReturn(schemaMapper);
+
+    // Prepare Real Avro Record
+    Schema payloadSchema =
+        org.apache.avro.SchemaBuilder.record("payload")
+            .fields()
+            .name("col1")
+            .type()
+            .stringType()
+            .noDefault()
+            .endRecord();
+    GenericRecord payload = new org.apache.avro.generic.GenericData.Record(payloadSchema);
+    payload.put("col1", "value1");
+
+    Schema avroSchema =
+        org.apache.avro.SchemaBuilder.record("avroRecord")
+            .fields()
+            .name("tableName")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("shardId")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("payload")
+            .type(payloadSchema)
+            .noDefault()
+            .endRecord();
+
+    GenericRecord avroRecord = new org.apache.avro.generic.GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "SourceTable");
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    when(context.element()).thenReturn(avroRecord);
+
+    // Mock SchemaMapper behavior
+    when(schemaMapper.getSpannerTableName(anyString(), eq("SourceTable")))
+        .thenReturn("SpannerTable");
+    when(schemaMapper.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+    when(schemaMapper.getSpannerColumns(anyString(), eq("SpannerTable")))
+        .thenReturn(ImmutableList.of("col1"));
+    when(schemaMapper.getSpannerColumnType(anyString(), eq("SpannerTable"), eq("col1")))
+        .thenReturn(com.google.cloud.teleport.v2.spanner.type.Type.string());
+    when(schemaMapper.getSourceColumnName(anyString(), eq("SpannerTable"), eq("col1")))
+        .thenReturn("col1");
+    when(schemaMapper.colExistsAtSource(anyString(), eq("SpannerTable"), eq("col1")))
+        .thenReturn(true);
+
+    // Mock DDL behavior
+    Table table = mock(Table.class);
+    when(ddl.table("SpannerTable")).thenReturn(table);
+    // Mock PKs
+    IndexColumn pkColumn = mock(IndexColumn.class);
+    when(pkColumn.name()).thenReturn("col1");
+    when(table.primaryKeys()).thenReturn(ImmutableList.of(pkColumn));
+
+    // Execute
+    SourceHashFn fn = new SourceHashFn(ddlView, schemaMapperProvider);
+    fn.processElement(context);
+    fn.processElement(context);
+
+    // Verify output
+    ArgumentCaptor<ComparisonRecord> captor = ArgumentCaptor.forClass(ComparisonRecord.class);
+    verify(context, org.mockito.Mockito.times(2)).output(captor.capture());
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/dofn/SpannerHashFnTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/dofn/SpannerHashFnTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.dofn;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.v2.dto.ComparisonRecord;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
+import com.google.common.collect.ImmutableList;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+
+@RunWith(JUnit4.class)
+public class SpannerHashFnTest {
+
+  @Test
+  public void testProcessElement() {
+    // Mock dependencies
+    PCollectionView<Ddl> ddlView = mock(PCollectionView.class);
+    SerializableFunction<Ddl, ISchemaMapper> schemaMapperProvider =
+        mock(SerializableFunction.class);
+    ISchemaMapper schemaMapper = mock(ISchemaMapper.class);
+    Ddl ddl = mock(Ddl.class);
+    DoFn<Struct, ComparisonRecord>.ProcessContext context = mock(DoFn.ProcessContext.class);
+
+    // Prepare behavior
+    when(context.sideInput(ddlView)).thenReturn(ddl);
+    when(schemaMapperProvider.apply(ddl)).thenReturn(schemaMapper);
+
+    // Prepare Input Struct
+    Struct spannerStruct =
+        Struct.newBuilder().set("id").to("123").set("__tableName__").to("SpannerTable").build();
+    when(context.element()).thenReturn(spannerStruct);
+
+    // Mock DDL behavior
+    Table table = mock(Table.class);
+    when(ddl.table("SpannerTable")).thenReturn(table);
+    // Mock PKs
+    IndexColumn pkColumn = mock(IndexColumn.class);
+    when(pkColumn.name()).thenReturn("id");
+    when(table.primaryKeys()).thenReturn(ImmutableList.of(pkColumn));
+
+    // Execute
+    SpannerHashFn fn = new SpannerHashFn(ddlView, schemaMapperProvider);
+    fn.processElement(context);
+    fn.processElement(context);
+
+    // Verify output
+    ArgumentCaptor<ComparisonRecord> captor = ArgumentCaptor.forClass(ComparisonRecord.class);
+    verify(context, org.mockito.Mockito.times(2)).output(captor.capture());
+
+    // We can verify properties if needed
+  }
+}


### PR DESCRIPTION
### TL;DR

Added three new DoFn classes for GCS-Spanner data validation pipeline: ProcessInformationSchemaFn for extracting Spanner schema information, SourceHashFn for converting source records to comparison format, and SpannerHashFn for converting Spanner records to comparison format.

### What changed?

- **ProcessInformationSchemaFn**: New DoFn that connects to Spanner, retrieves database dialect information, and scans the information schema to produce DDL objects using InformationSchemaScanner
- **SourceHashFn**: New DoFn that transforms GenericRecord objects from source data into ComparisonRecord objects using ComparisonRecordMapper with schema mapping support
- **SpannerHashFn**: New DoFn that transforms Spanner Struct objects into ComparisonRecord objects for data comparison purposes
- Added comprehensive unit tests for all three DoFn classes with proper mocking of dependencies

### How to test?

Run the new unit tests:
- `ProcessInformationSchemaFnTest` - Tests schema extraction from Spanner information schema
- `SourceHashFnTest` - Tests conversion of Avro GenericRecord to ComparisonRecord with mock schema mapping
- `SpannerHashFnTest` - Tests conversion of Spanner Struct to ComparisonRecord

### Why make this change?

These DoFn classes provide the core transformation logic needed for a data validation pipeline between GCS and Spanner. They enable schema introspection from Spanner databases and standardize both source and target data into a common ComparisonRecord format for validation processing.